### PR TITLE
Add CLAUDE.md and document AI Dev Kit + Claude Code in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ dist/
 build/
 coverage_reports/
 src/template.egg-info/
-CLAUDE.md
 *.pyc
 *.lock
 .coverage*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A production-ready PySpark/Databricks ETL pipeline template using medallion architecture, Python packaging, unit + integration tests, Databricks Declarative Automation Bundles (DABs), and DQX data quality framework. Code is structured as a Python wheel package (not notebooks) deployed to Databricks serverless.
+
+## Tooling: Databricks AI Dev Kit + MCP
+
+This project is developed with the [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit) installed at the user level (`~/.ai-dev-kit/`). It provides:
+
+- **Databricks MCP server** (`mcp__databricks__*` tools) — wired globally in `~/.claude.json`, authenticates via the `DEFAULT` profile in `~/.databrickscfg`.
+- **Databricks skills** (`databricks-bundles`, `databricks-jobs`, `databricks-python-sdk`, `databricks-config`, `databricks-unity-catalog`, etc.) — invoke via the Skill tool when the task matches.
+
+### When to use what
+
+- **Workspace/UC/Jobs/Pipelines/Apps/Serving operations** → prefer `mcp__databricks__*` tools over `databricks` CLI shell-outs or hand-rolled SDK scripts. Examples: `manage_jobs`, `manage_job_runs`, `manage_uc_objects`, `execute_sql`, `manage_serving_endpoint`, `manage_workspace_files`.
+- **Bundle work** (editing `databricks.yml`, `resources/*.yml`, deploy/run) → invoke the `databricks-bundles` skill. Note this project generates `resources/jobs.yml` via `scripts/sdk_generate_template_job.py`; do not hand-edit it.
+- **Adding/modifying jobs** → invoke `databricks-jobs` skill for guidance, but route changes through `scripts/sdk_generate_template_job.py` + `make deploy` (see "Adding a New Job" below).
+- **Switching workspaces / checking auth** → invoke `databricks-config` skill.
+- **SDK code inside `src/template/`** → invoke `databricks-python-sdk` skill.
+
+### Conventions
+
+- Use the `DEFAULT` profile unless told otherwise. To check or switch, use the `databricks-config` skill.
+- Do **not** install the Dev Kit into this repo or commit MCP config — it's a user-level tool. `.claude/` is currently untracked.
+- If MCP tools are unavailable in a session, fall back to the `databricks` CLI or `databricks-sdk` directly, but flag it to the user.
+
+## Commands
+
+```bash
+make sync              # Install all dependencies via uv
+make test              # Run pytest with coverage
+make pre-commit        # Update and run pre-commit hooks (ruff lint/format)
+make create-sp         # Create service principal for staging/prod
+make deploy env=dev    # Generate jobs.yml + deploy bundle to target env (dev/staging/prod)
+make run env=staging   # Run integration test job on staging
+```
+
+Run a single test file:
+```bash
+uv run pytest tests/job1/unit_test.py
+```
+
+Run a single test by name:
+```bash
+uv run pytest tests/job1/unit_test.py::test_enrich_orders
+```
+
+## Architecture
+
+### Execution Flow
+
+`main.py` parses CLI args → instantiates `Config` → dispatches to a task class via `TASKS` dict → calls `.run()`.
+
+Each Databricks job task maps to one class. The `--task` arg value must match a key in `TASKS`. Job definitions are **generated** (not hand-authored) by `scripts/sdk_generate_template_job.py` into `resources/jobs.yml`, which is then consumed by the bundle. Never edit `resources/jobs.yml` directly.
+
+### Key Classes
+
+- **`Config`** ([src/template/config.py](src/template/config.py)) — holds all runtime params, creates the `SparkSession`, sets the Unity Catalog default, and exposes `dq_engine` (DQX). When `env=local` (unit tests), it mocks the `WorkspaceClient` so tests run without Databricks connectivity.
+- **`BaseTask`** ([src/template/baseTask.py](src/template/baseTask.py)) — minimal base class; gives every task `self.spark` and `self.config`.
+- **Task classes** (e.g. `ExtractSource1`, `GenerateOrders`) — subclass `BaseTask`, implement `run()`. Transformation logic lives in dedicated methods (e.g. `enrich_order`) so unit tests can call them directly without Spark tables.
+
+### Medallion Layers (Unity Catalog Schemas)
+
+| Schema | Content |
+|---|---|
+| `external_source` | Raw input data (seeded by integration test `setup` task) |
+| `raw` | Bronze — direct copies from sources |
+| `curated` | Silver — joined/enriched tables |
+| `report` | Gold — aggregated tables |
+
+### Environments & Catalogs
+
+- `dev` — catalog name = developer's short username (isolated per developer, prevents concurrency conflicts)
+- `staging` / `prod` — catalog name matches environment; runs as service principal
+
+### Data Quality (DQX)
+
+`ExtractSource2` demonstrates the DQX pattern: define rules as `DQRowRule`/`DQForEachColRule`/`DQDatasetRule`, call `dq_engine.apply_checks_and_split()`, write invalid rows to a `_quarantine` table.
+
+### Testing Pattern
+
+Unit tests use `env=local` which bypasses Databricks catalog setup and mocks `WorkspaceClient`. Test transformation methods directly (e.g., `task.enrich_order(df1, df2, df3)`) using in-memory DataFrames. Integration tests use the `setup` → `run` → `validate` job sequence on staging.
+
+### CI/CD (GitHub Actions)
+
+On every push: install deps → unit tests → deploy to staging → run integration tests → deploy to prod. Requires `DATABRICKS_HOST` and `DATABRICKS_TOKEN` secrets.
+
+### Adding a New Job
+
+1. Create task classes under `src/template/<jobN>/`, inheriting `BaseTask`.
+2. Register them in `TASKS` dict in `main.py`.
+3. Add task construction logic to `scripts/sdk_generate_template_job.py`.
+4. Run `make deploy env=dev` to regenerate `resources/jobs.yml` and deploy.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Interested in bringing these principles in your own project?  Let’s [connect o
 
 This project template demonstrates how to:
 
+- use agentic development (with Databricks AI Dev Kit and Claude Code) in data projects.
 - structure PySpark code inside classes/packages, instead of notebooks.
 - package and deploy code to different environments (dev, staging, prod). 
 - use a CI/CD pipeline with [Github Actions](https://docs.github.com/en/actions).
@@ -63,7 +64,11 @@ This project template demonstrates how to:
 
 ## 🧠 Resources
 
-For a debate on the use of notebooks vs. Python packaging, please refer to:
+Agentic development:
+- [Mastering Claude Code in 30 minutes](https://www.youtube.com/watch?v=6eBSHbLKuN0)
+- [Introducing Databricks AI Dev Kit - Skills, MCP server, Builder App](https://www.youtube.com/watch?v=HFSIKrG8bRg)
+
+Debates on the use of notebooks vs. Python packaging:
 - [The Rise of The Notebook Engineer](https://dataengineeringcentral.substack.com/p/the-rise-of-the-notebook-engineer)
 - [Please don’t make me use Databricks notebooks](https://medium.com/@seade03/please-dont-make-me-use-databricks-notebooks-3d07a4a332ae)
 - [this Linkedin thread by Daniel Beach](https://www.linkedin.com/posts/daniel-beach-6ab8b4132_dataengineering-databricks-activity-7171661784997715968-OpRW)
@@ -75,11 +80,10 @@ Sessions on Databricks Declarative Automation Bundles, CI/CD, and Software Devel
 - [Deploying Databricks Asset Bundles (DABs) at Scale](https://www.youtube.com/watch?v=mMwprgB-sIU)
 - [A Prescription for Success: Leveraging DABs for Faster Deployment and Better Patient Outcomes](https://www.youtube.com/watch?v=01JHTM2UP-U)
 
-Other:
+Other resources:
 - [Goodbye Pip and Poetry. Why UV Might Be All You Need](https://codecut.ai/why-uv-might-all-you-need/)
 - [The Spark Revolution You Didn’t See Coming: How Apache Spark 4.0 in Databricks Just Changed Everything](https://medium.com/@matiasmaquieira96/the-spark-revolution-you-didnt-see-coming-how-apache-spark-4-0-2a6422144f67)
-- [Mastering Claude Code in 30 minutes](https://www.youtube.com/watch?v=6eBSHbLKuN0)
-- [Introducing Databricks AI Dev Kit - Skills, MCP server, Builder App](https://www.youtube.com/watch?v=HFSIKrG8bRg)
+
 
 
 ## 📁 Folder Structure

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Interested in bringing these principles in your own project?  Let’s [connect o
 - Databricks CLI
 - Databricks Python SDK
 - Databricks DQX
+- Databricks AI Dev Kit
+- Claude Code
 - PySpark 4.1
 - Python 3.12+
 - GitHub Actions
@@ -76,6 +78,9 @@ Sessions on Databricks Declarative Automation Bundles, CI/CD, and Software Devel
 Other:
 - [Goodbye Pip and Poetry. Why UV Might Be All You Need](https://codecut.ai/why-uv-might-all-you-need/)
 - [The Spark Revolution You Didn’t See Coming: How Apache Spark 4.0 in Databricks Just Changed Everything](https://medium.com/@matiasmaquieira96/the-spark-revolution-you-didnt-see-coming-how-apache-spark-4-0-2a6422144f67)
+- [Mastering Claude Code in 30 minutes](https://www.youtube.com/watch?v=6eBSHbLKuN0)
+- [Introducing Databricks AI Dev Kit - Skills, MCP server, Builder App](https://www.youtube.com/watch?v=HFSIKrG8bRg)
+
 
 ## 📁 Folder Structure
 
@@ -177,21 +182,23 @@ databricks-template/
 ## Instructions
 
 
-1) Create a workspace. Use a [Databricks Free Edition](https://docs.databricks.com/aws/en/getting-started/free-edition) workspace.
+1) (Optional) Install [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit) and [Claude Code](https://code.claude.com/docs/en/vs-code).
+
+2) Create a workspace. Use a [Databricks Free Edition](https://docs.databricks.com/aws/en/getting-started/free-edition) workspace.
 
 
-2) Install and configure Databricks CLI on your local machine. Check the current version on databricks.yaml. Follow instructions [here](https://docs.databricks.com/en/dev-tools/cli/install.html). 
+3) Install and configure Databricks CLI on your local machine. Check the current version on databricks.yaml. Follow instructions [here](https://docs.databricks.com/en/dev-tools/cli/install.html). 
 
 
-3) Build Python env and execute unit tests on your local machine.
+4) Build Python env and execute unit tests on your local machine.
 
         make sync & make test
         
-4) Create an external location in Databricks and update the "storage-root" parameter in the Makefile. This step will create the catalogs, schemas, service principal, and the required grants. For more details, see [Overview of external locations](https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage#external-locations). Then run:
+5) Create an external location in Databricks and update the "storage-root" parameter in the Makefile. This step will create the catalogs, schemas, service principal, and the required grants. For more details, see [Overview of external locations](https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage#external-locations). Then run:
 
         make init
 
-5) Generate a secret for the service principal. In Databricks, go to: Workspace -> Settings -> Identity and access -> Service principals -> Secrets. Generate a new secret for your service principal and update the corresponding profiles in your .databrickscfg file. Your configuration should look similar to this:
+6) Generate a secret for the service principal. In Databricks, go to: Workspace -> Settings -> Identity and access -> Service principals -> Secrets. Generate a new secret for your service principal and update the corresponding profiles in your .databrickscfg file. Your configuration should look similar to this:
 
         [dev]
         host             = https://xxxx.cloud.databricks.com/
@@ -207,14 +214,14 @@ databricks-template/
         client_id     = yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
         client_secret = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-6) Deploy and execute on the dev workspace.
+7) Deploy and execute on the dev workspace.
 
         make deploy env=dev
 
 
-7) Configure CI/CD automation with the service principal ID and Secret. Configure [Github Actions repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) (DATABRICKS_HOST, DATABRICKS_PRINCIPAL_ID, DATABRICKS_SECRET).
+8) Configure CI/CD automation with the service principal ID and Secret. Configure [Github Actions repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) (DATABRICKS_HOST, DATABRICKS_PRINCIPAL_ID, DATABRICKS_SECRET).
 
-8) You can also execute unit tests from your preferred IDE. Here's a screenshot from [VS Code](https://code.visualstudio.com/) with [Microsoft's Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed.
+9) (Optional) You can also execute unit tests from your preferred IDE. Here's a screenshot from [VS Code](https://code.visualstudio.com/) with [Microsoft's Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed.
 
 - <img src="docs/vscode.png">
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` at the project root with tooling, architecture, commands, and conventions for the Databricks AI Dev Kit + MCP workflow
- Update `README.md` to list Databricks AI Dev Kit and Claude Code, link related videos, and include an optional install step
- Keep `.claude/` gitignored so per-developer `settings.local.json` stays local; only `CLAUDE.md` is tracked

## Test plan
- [ ] CI passes on the new branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)