### PR TITLE
feat: add seed_sources task with --seed-date parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ The wheel entry point is intentionally minimal:
 - `--run-id` *(optional, observability-only)* — filled by Databricks via `{{job.run_id}}`. Stamped onto every log line via a `logging.Filter` so logs are correlatable after ingest. Defaults to `-` when absent (e.g. local tests).
 - `--log-level` *(optional)* — `DEBUG`/`INFO`/`WARNING`. Filled from the job-level parameter `log_level` (default `INFO`). Override per-run from the Databricks Jobs UI "Run with different parameters" dialog.
 - `--quarantine-fail-ratio` *(optional)* — float threshold for DQX hard-fail in `extract_source2`. Filled from the job-level parameter `quarantine_fail_ratio` (default `1.0` in dev/staging, `0.1` in prod).
+- `--seed-date` *(optional)* — ISO-8601 date (e.g. `2024-03-15`) consumed by `seed_sources`. Filled from the job-level parameter `seed_date` (default `""` → resolved to today at runtime). Override per-run to backfill a specific day.
 
 Anything tunable at runtime is a **CLI arg** populated from a Databricks job-level parameter — not an environment variable. Serverless compute does not expose custom env vars to the process.
 
@@ -86,7 +87,7 @@ Medallion schemas (`MEDALLION_SCHEMAS` in `config.py`):
 
 | Schema | Content |
 |---|---|
-| `external_source` | Raw input data (seeded by integration test `setup` task) |
+| `external_source` | Raw input data — populated by `seed_sources` task (daily) in normal runs; destructively reset by the integration test `setup` task before each test run |
 | `raw` | Bronze — direct copies from sources |
 | `curated` | Silver — joined/enriched tables |
 | `report` | Gold — aggregated tables |
@@ -102,6 +103,7 @@ Defined as `JobParameterDefinition` in `sdk_generate_template_job.py` and refere
 |---|---|---|---|
 | `log_level` | `DEBUG`/`INFO`/`WARNING`. Bump to `DEBUG` for a single run during prod incident response. | `INFO` | `INFO` |
 | `quarantine_fail_ratio` | Hard-fail `extract_source2` if more than this fraction of rows are quarantined by DQX. | `1.0` (disabled) | `0.1` |
+| `seed_date` | ISO-8601 date consumed by `seed_sources`. Empty string (default) resolves to today at runtime. Override to backfill a specific day (e.g. `"2024-03-15"`). | `""` → today | `""` → today |
 
 ### Deploy-time environment variables (CI/build machine only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Medallion schemas (`MEDALLION_SCHEMAS` in `config.py`):
 
 | Schema | Content |
 |---|---|
-| `external_source` | Raw input data — populated by `seed_sources` task (daily) in normal runs; destructively reset by the integration test `setup` task before each test run |
+| `external_source` | Raw input data — populated by `seed_sources` task (prod only, daily); seeded with controlled data by the integration test `setup` task (dev/staging) |
 | `raw` | Bronze — direct copies from sources |
 | `curated` | Silver — joined/enriched tables |
 | `report` | Gold — aggregated tables |

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ These are defined as `JobParameterDefinition` in `scripts/sdk_generate_template_
 |---|---|---|---|---|
 | `log_level` | `--log-level` | `DEBUG` / `INFO` / `WARNING`. Bump to `DEBUG` for a single prod run during incident response. | `INFO` | `INFO` |
 | `quarantine_fail_ratio` | `--quarantine-fail-ratio` | Hard-fail `extract_source2` if more than this fraction of rows are quarantined by DQX. Defaults to disabled so demo seed data still ingests. | `1.0` | `0.1` |
+| `seed_date` | `--seed-date` | ISO-8601 date (e.g. `2024-03-15`) for the `seed_sources` task. Empty string (default) resolves to today's date at runtime. Override per-run to backfill a specific day. | `""` → today | `""` → today |
 
 ## Deploy-time environment variables (CI/build machine only)
 

--- a/scripts/sdk_generate_template_job.py
+++ b/scripts/sdk_generate_template_job.py
@@ -86,6 +86,7 @@ def _wheel_task() -> PythonWheelTask:
             "--run-id={{job.run_id}}",
             "--log-level={{job.parameters.log_level}}",
             "--quarantine-fail-ratio={{job.parameters.quarantine_fail_ratio}}",
+            "--seed-date={{job.parameters.seed_date}}",
         ],
     )
 
@@ -172,7 +173,20 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
             )
         )
 
-    extract_deps: list[TaskDependency] = [TaskDependency(task_key="health_check")] if environment == "prod" else []
+    # seed_sources always runs before extract tasks; in prod it waits for health_check first.
+    seed_deps: list[TaskDependency] = [TaskDependency(task_key="health_check")] if environment == "prod" else []
+    tasks.append(
+        Task(
+            task_key="seed_sources",
+            **_retry_kwargs(retries),
+            timeout_seconds=TIMEOUT_EXTRACT_S,
+            environment_key="default",
+            depends_on=seed_deps or None,
+            python_wheel_task=_wheel_task(),
+        )
+    )
+
+    extract_deps: list[TaskDependency] = [TaskDependency(task_key="seed_sources")]
 
     tasks.extend(
         [
@@ -181,7 +195,7 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
                 **_retry_kwargs(retries),
                 timeout_seconds=TIMEOUT_EXTRACT_S,
                 environment_key="default",
-                depends_on=extract_deps or None,
+                depends_on=extract_deps,
                 python_wheel_task=_wheel_task(),
             ),
             Task(
@@ -189,7 +203,7 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
                 **_retry_kwargs(retries),
                 timeout_seconds=TIMEOUT_EXTRACT_S,
                 environment_key="default",
-                depends_on=extract_deps or None,
+                depends_on=extract_deps,
                 python_wheel_task=_wheel_task(),
             ),
             Task(
@@ -255,6 +269,9 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
                 name="quarantine_fail_ratio",
                 default=PROD_QUARANTINE_FAIL_RATIO if environment == "prod" else DEFAULT_QUARANTINE_FAIL_RATIO,
             ),
+            # Empty string → SeedSources resolves to today's date at runtime.
+            # Override per-run (e.g. "2024-03-15") to backfill a specific day.
+            JobParameterDefinition(name="seed_date", default=""),
         ],
         tags=_tags(environment),
         environments=_environments(),
@@ -310,6 +327,7 @@ def _build_job_integration_test(environment: str, sp_id: str | None) -> dict:
         parameters=[
             JobParameterDefinition(name="log_level", default=DEFAULT_LOG_LEVEL),
             JobParameterDefinition(name="quarantine_fail_ratio", default=DEFAULT_QUARANTINE_FAIL_RATIO),
+            JobParameterDefinition(name="seed_date", default=""),
         ],
         tags=_tags(environment),
         environments=_environments(),

--- a/scripts/sdk_generate_template_job.py
+++ b/scripts/sdk_generate_template_job.py
@@ -173,20 +173,22 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
             )
         )
 
-    # seed_sources always runs before extract tasks; in prod it waits for health_check first.
-    seed_deps: list[TaskDependency] = [TaskDependency(task_key="health_check")] if environment == "prod" else []
-    tasks.append(
-        Task(
-            task_key="seed_sources",
-            **_retry_kwargs(retries),
-            timeout_seconds=TIMEOUT_EXTRACT_S,
-            environment_key="default",
-            depends_on=seed_deps or None,
-            python_wheel_task=_wheel_task(),
+    # seed_sources runs only in prod: staging/dev use the integration test `setup` task
+    # to seed external_source with controlled data, so seed_sources would add noise there.
+    # In prod, seed_sources runs after health_check and before the extract tasks.
+    if environment == "prod":
+        tasks.append(
+            Task(
+                task_key="seed_sources",
+                **_retry_kwargs(retries),
+                timeout_seconds=TIMEOUT_EXTRACT_S,
+                environment_key="default",
+                depends_on=[TaskDependency(task_key="health_check")],
+                python_wheel_task=_wheel_task(),
+            )
         )
-    )
 
-    extract_deps: list[TaskDependency] = [TaskDependency(task_key="seed_sources")]
+    extract_deps: list[TaskDependency] = [TaskDependency(task_key="seed_sources")] if environment == "prod" else []
 
     tasks.extend(
         [
@@ -195,7 +197,7 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
                 **_retry_kwargs(retries),
                 timeout_seconds=TIMEOUT_EXTRACT_S,
                 environment_key="default",
-                depends_on=extract_deps,
+                depends_on=extract_deps or None,
                 python_wheel_task=_wheel_task(),
             ),
             Task(
@@ -203,7 +205,7 @@ def _build_job(environment: str, sp_id: str | None) -> dict:
                 **_retry_kwargs(retries),
                 timeout_seconds=TIMEOUT_EXTRACT_S,
                 environment_key="default",
-                depends_on=extract_deps,
+                depends_on=extract_deps or None,
                 python_wheel_task=_wheel_task(),
             ),
             Task(

--- a/src/template/config.py
+++ b/src/template/config.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import date as _date
 
 from databricks.labs.dqx.engine import DQEngine
 from databricks.sdk import WorkspaceClient
@@ -55,6 +56,13 @@ class Config:
         log_level = args.log_level.upper()
         self.params.update({"log_level": log_level})
         self.params.update({"quarantine_fail_ratio": args.quarantine_fail_ratio})
+
+        # --seed-date is a job-level parameter filled by {{job.parameters.seed_date}}.
+        # An empty string (the job default) resolves to today so every daily run seeds
+        # the current date without any operator action. Operators can override it per-run
+        # (e.g. "2024-03-15") to backfill a specific day.
+        seed_date = (getattr(args, "seed_date", None) or "").strip() or _date.today().isoformat()
+        self.params.update({"seed_date": seed_date})
 
         # run_id comes from --run-id={{job.run_id}}. Not exposed as an env var on serverless,
         # so it has to be threaded through as a CLI param. Falls back to "-" for local tests.

--- a/src/template/job1/seed_sources.py
+++ b/src/template/job1/seed_sources.py
@@ -1,0 +1,129 @@
+from datetime import date as _date
+
+from pyspark.sql import DataFrame
+
+from ..baseTask import BaseTask
+from ..commonSchemas import customer_schema, order_item_schema, order_schema
+
+SCHEMA = "external_source"
+
+# Synthetic ID space starts at 1_000 and grows by 10 per day so there is no
+# overlap with integration-test rows (customer ids 10/20, order ids 1-3).
+_EPOCH = _date(2024, 1, 1)
+
+
+def _day_offset(seed_date: str) -> int:
+    """Days since _EPOCH — deterministic, collision-free index per calendar day."""
+    return max(0, (_date.fromisoformat(seed_date) - _EPOCH).days)
+
+
+def _base_id(seed_date: str) -> int:
+    """First synthetic primary-key value available for seed_date (10 IDs reserved/day)."""
+    return _day_offset(seed_date) * 10 + 1_000
+
+
+class SeedSources(BaseTask):
+    """
+    Idempotent daily seeder for external_source tables.
+
+    On first run: creates each table from its declared schema if it does not
+    exist yet (``mode="ignore"`` is a no-op when the table is already present).
+    On every run: appends one day's worth of synthetic rows keyed by seed_date,
+    using MERGE-by-primary-key so reruns of the same day are safe no-ops.
+
+    In a real pipeline, replace the ``_generate_*`` methods with reads from
+    your actual upstream source (S3 landing zone, JDBC connection, REST API,
+    Kafka topic, etc.).  The ``_upsert_*`` helpers stay unchanged.
+    """
+
+    def run(self) -> None:
+        catalog = self.config.get_value("catalog")
+        seed_date = self.config.get_value("seed_date")
+        self.logger.info("seeding external_source tables catalog=%s date=%s", catalog, seed_date)
+
+        self._ensure_tables(catalog)
+
+        n_customers = self._upsert_customers(catalog, seed_date)
+        n_orders, n_items = self._upsert_orders(catalog, seed_date)
+
+        self.logger.info(
+            "seed complete customers_upserted=%d orders_upserted=%d items_upserted=%d",
+            n_customers,
+            n_orders,
+            n_items,
+        )
+
+    # ------------------------------------------------------------------
+    # Table bootstrap (idempotent CREATE IF NOT EXISTS)
+    # ------------------------------------------------------------------
+
+    def _ensure_tables(self, catalog: str) -> None:
+        """Create each external_source table from its declared schema when absent."""
+        for name, schema in (
+            ("customer", customer_schema),
+            ("order", order_schema),
+            ("order_item", order_item_schema),
+        ):
+            (self.spark.createDataFrame([], schema).write.mode("ignore").saveAsTable(f"{catalog}.{SCHEMA}.{name}"))
+            self.logger.info("ensured table %s.%s.%s", catalog, SCHEMA, name)
+
+    # ------------------------------------------------------------------
+    # Synthetic row generators
+    # Replace with real upstream reads in production.
+    # ------------------------------------------------------------------
+
+    def _generate_customers(self, seed_date: str) -> DataFrame:
+        """One new customer per day; id derived from seed_date so there are no cross-day collisions."""
+        base = _base_id(seed_date)
+        rows = [(base, f"Customer_{base}", "US")]
+        return self.spark.createDataFrame(rows, schema=customer_schema)
+
+    def _generate_orders(self, seed_date: str) -> DataFrame:
+        """Two new orders per day, both belonging to today's customer."""
+        base = _base_id(seed_date)
+        rows = [
+            (base, base, 99.9, seed_date),
+            (base + 1, base, 49.5, seed_date),
+        ]
+        return self.spark.createDataFrame(rows, schema=order_schema)
+
+    def _generate_order_items(self, seed_date: str) -> DataFrame:
+        """Three line items: two for the first order of the day, one for the second."""
+        base = _base_id(seed_date)
+        rows = [
+            (base, 1, "Widget A", 2, 49.95),
+            (base, 2, "Widget B", 1, 49.95),
+            (base + 1, 1, "Widget C", 1, 49.5),
+        ]
+        return self.spark.createDataFrame(rows, schema=order_item_schema)
+
+    # ------------------------------------------------------------------
+    # Upsert helpers — MERGE by PK so reruns on the same day are no-ops
+    # ------------------------------------------------------------------
+
+    def _upsert_customers(self, catalog: str, seed_date: str) -> int:
+        df = self._generate_customers(seed_date)
+        df.createOrReplaceTempView("_seed_customers")
+        self.spark.sql(f"""
+            MERGE INTO {catalog}.{SCHEMA}.customer AS t
+            USING _seed_customers AS s ON t.id = s.id
+            WHEN NOT MATCHED THEN INSERT *
+        """)
+        return df.count()
+
+    def _upsert_orders(self, catalog: str, seed_date: str) -> tuple[int, int]:
+        df_orders = self._generate_orders(seed_date)
+        df_items = self._generate_order_items(seed_date)
+        df_orders.createOrReplaceTempView("_seed_orders")
+        df_items.createOrReplaceTempView("_seed_order_items")
+        self.spark.sql(f"""
+            MERGE INTO {catalog}.{SCHEMA}.order AS t
+            USING _seed_orders AS s ON t.id = s.id
+            WHEN NOT MATCHED THEN INSERT *
+        """)
+        self.spark.sql(f"""
+            MERGE INTO {catalog}.{SCHEMA}.order_item AS t
+            USING _seed_order_items AS s ON t.id_order = s.id_order AND t.seq = s.seq
+            WHEN NOT MATCHED THEN INSERT *
+        """)
+        return df_orders.count(), df_items.count()

--- a/src/template/main.py
+++ b/src/template/main.py
@@ -11,15 +11,17 @@ from .job1.extract_source2 import ExtractSource2
 from .job1.generate_orders import GenerateOrders
 from .job1.generate_orders_agg import GenerateOrdersAgg
 from .job1.health_check import HealthCheck
+from .job1.seed_sources import SeedSources
 
 TASKS = {
     "extract_source1": ExtractSource1,
     "extract_source2": ExtractSource2,
     "generate_orders": GenerateOrders,
     "generate_orders_agg": GenerateOrdersAgg,
+    "health_check": HealthCheck,
+    "seed_sources": SeedSources,
     "setup": Setup,
     "validate": Validate,
-    "health_check": HealthCheck,
 }
 
 
@@ -33,6 +35,9 @@ def arg_parser():
     parser.add_argument("--run-id")
     parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARN", "WARNING"])
     parser.add_argument("--quarantine-fail-ratio", type=float, default=1.0)
+    # ISO-8601 date (YYYY-MM-DD). Empty string or absent → resolved to today by Config.
+    # Filled by {{job.parameters.seed_date}}; override per-run for backfills.
+    parser.add_argument("--seed-date", default=None)
 
     return parser
 

--- a/tests/job1/integration_validate.py
+++ b/tests/job1/integration_validate.py
@@ -1,13 +1,7 @@
-from pyspark.sql.functions import col
 from pyspark.sql.types import DoubleType, LongType, StringType, StructField, StructType
 from pyspark.testing import assertDataFrameEqual
 
 from template.baseTask import BaseTask
-
-# Customers seeded by integration_setup.py with deterministic, known values.
-# seed_sources adds synthetic rows on top of these; we filter to setup customers
-# so the assertion is stable regardless of which seed_date was used.
-_SETUP_CUSTOMERS = ["John Doe", "Jane Smith"]
 
 
 class Validate(BaseTask):
@@ -19,13 +13,9 @@ class Validate(BaseTask):
 
         df_out = self.spark.table("report.order_agg")
 
-        # Filter to the two customers seeded by setup so the check is not
-        # sensitive to extra rows introduced by seed_sources on the same run.
-        df_setup = df_out.filter(col("name").isin(_SETUP_CUSTOMERS))
-
-        count = df_setup.count()
+        count = df_out.count()
         if count != 2:
-            raise RuntimeError(f"Expected 2 rows for setup customers in report.order_agg, got {count}")
+            raise RuntimeError(f"Expected 2 rows in report.order_agg, got {count}")
 
         expected_data = [
             ("John Doe", 3, 100.0),
@@ -40,4 +30,4 @@ class Validate(BaseTask):
         )
         df_expected = self.spark.createDataFrame(expected_data, schema=expected_schema)
 
-        assertDataFrameEqual(df_setup, df_expected)
+        assertDataFrameEqual(df_out, df_expected)

--- a/tests/job1/integration_validate.py
+++ b/tests/job1/integration_validate.py
@@ -1,7 +1,13 @@
+from pyspark.sql.functions import col
 from pyspark.sql.types import DoubleType, LongType, StringType, StructField, StructType
 from pyspark.testing import assertDataFrameEqual
 
 from template.baseTask import BaseTask
+
+# Customers seeded by integration_setup.py with deterministic, known values.
+# seed_sources adds synthetic rows on top of these; we filter to setup customers
+# so the assertion is stable regardless of which seed_date was used.
+_SETUP_CUSTOMERS = ["John Doe", "Jane Smith"]
 
 
 class Validate(BaseTask):
@@ -13,9 +19,13 @@ class Validate(BaseTask):
 
         df_out = self.spark.table("report.order_agg")
 
-        count = df_out.count()
+        # Filter to the two customers seeded by setup so the check is not
+        # sensitive to extra rows introduced by seed_sources on the same run.
+        df_setup = df_out.filter(col("name").isin(_SETUP_CUSTOMERS))
+
+        count = df_setup.count()
         if count != 2:
-            raise RuntimeError(f"Expected 2 rows in report.order_agg, got {count}")
+            raise RuntimeError(f"Expected 2 rows for setup customers in report.order_agg, got {count}")
 
         expected_data = [
             ("John Doe", 3, 100.0),
@@ -30,4 +40,4 @@ class Validate(BaseTask):
         )
         df_expected = self.spark.createDataFrame(expected_data, schema=expected_schema)
 
-        assertDataFrameEqual(df_out, df_expected)
+        assertDataFrameEqual(df_setup, df_expected)

--- a/tests/job1/unit_test.py
+++ b/tests/job1/unit_test.py
@@ -8,6 +8,7 @@ from template.main import *
 from template.config import Config as TaskConfig
 from template.job1.generate_orders import GenerateOrders
 from template.job1.generate_orders_agg import GenerateOrdersAgg
+from template.job1.seed_sources import SeedSources, _base_id, _day_offset
 from template.commonSchemas import customer_schema, order_schema, order_item_schema
 
 from pyspark.testing import assertDataFrameEqual
@@ -32,6 +33,7 @@ def config() -> TaskConfig:
             env="local",
             log_level="INFO",
             quarantine_fail_ratio=1.0,
+            seed_date="2024-01-01",  # fixed date so tests are deterministic
         )
     )
 
@@ -81,7 +83,7 @@ def test_arg_parser():
     args = parser.parse_args(["--task=extract_source1", "--env=dev"])
 
     assert args == Namespace(
-        task="extract_source1", env="dev", run_id=None, log_level="INFO", quarantine_fail_ratio=1.0
+        task="extract_source1", env="dev", run_id=None, log_level="INFO", quarantine_fail_ratio=1.0, seed_date=None
     )
 
 
@@ -94,12 +96,14 @@ def test_arg_parser():
                 env="local",
                 log_level="INFO",
                 quarantine_fail_ratio=1.0,
+                seed_date="2024-01-01",
             ),
             {
                 "task": "extract_source1",
                 "env": "local",
                 "log_level": "INFO",
                 "quarantine_fail_ratio": 1.0,
+                "seed_date": "2024-01-01",
             },
         ),
     ],
@@ -185,3 +189,42 @@ def test_aggregate_orders(spark, config, df_orders):
     df_expected = spark.createDataFrame(expected_data, schema=expected_schema)
 
     assertDataFrameEqual(df_out, df_expected)
+
+
+# ---------------------------------------------------------------------------
+# SeedSources — generator methods only (no Spark tables, runs in local mode)
+# ---------------------------------------------------------------------------
+
+
+def test_seed_sources_generate_customers(spark, config):
+    task = SeedSources(config)
+    df = task._generate_customers("2024-01-01")
+    assert df.count() == 1
+    assert df.schema == customer_schema
+
+
+def test_seed_sources_generate_orders(spark, config):
+    task = SeedSources(config)
+    df = task._generate_orders("2024-01-01")
+    assert df.count() == 2
+    assert df.schema == order_schema
+    # All generated orders are dated to seed_date
+    dates = {row.date for row in df.collect()}
+    assert dates == {"2024-01-01"}
+
+
+def test_seed_sources_generate_order_items(spark, config):
+    task = SeedSources(config)
+    df = task._generate_order_items("2024-01-01")
+    assert df.count() == 3
+    assert df.schema == order_item_schema
+
+
+def test_seed_sources_daily_ids_are_unique(spark, config):
+    """Customer and order IDs generated for consecutive days must not collide."""
+    task = SeedSources(config)
+    ids_day0 = {row.id for row in task._generate_customers("2024-01-01").collect()}
+    ids_day0 |= {row.id for row in task._generate_orders("2024-01-01").collect()}
+    ids_day1 = {row.id for row in task._generate_customers("2024-01-02").collect()}
+    ids_day1 |= {row.id for row in task._generate_orders("2024-01-02").collect()}
+    assert ids_day0.isdisjoint(ids_day1)


### PR DESCRIPTION
## What

Adds a `SeedSources` task that creates and daily-updates the `external_source` tables in **prod**, plus the `--seed-date` job-level parameter that controls which day is seeded.

## Why

`external_source.*` tables did not exist in prod — the only seeding mechanism was the integration test `setup` task, which is destructive (drops all schemas) and only runs in dev/staging. Production ETL jobs would fail at the first `READ` with a table-not-found error.

`seed_sources` is intentionally **prod-only**: in dev/staging the integration test `setup` task owns `external_source` with controlled data; running `seed_sources` there would add noise on top of that.

## Design

### `src/template/job1/seed_sources.py` (new)

| Method | Purpose |
|---|---|
| `_ensure_tables` | `CREATE TABLE IF NOT EXISTS` via `mode="ignore"` — idempotent, safe on every run |
| `_generate_customers/orders/order_items` | Synthetic row generators keyed by `seed_date`. IDs start at `1000 + day_offset × 10` — no collision with integration-test rows. **Replace these with real upstream reads** (S3, JDBC, REST API, Kafka) in production |
| `_upsert_*` | `MERGE INTO … WHEN NOT MATCHED THEN INSERT *` by primary key — reruns of the same `seed_date` are safe no-ops |

### DAG change (prod only)

```
prod:        health_check → seed_sources → [extract_source1, extract_source2] → generate_orders → generate_orders_agg
dev/staging:                               [extract_source1, extract_source2] → generate_orders → generate_orders_agg
```

### New job-level parameter: `seed_date`

| | |
|---|---|
| Default | `""` → resolved to `date.today().isoformat()` at runtime |
| Override | Pass `"2024-03-15"` from the Jobs UI "Run with different parameters" dialog to backfill a specific day |

### Unit tests (4 new)

- `test_seed_sources_generate_customers` — schema + count
- `test_seed_sources_generate_orders` — schema, count, date field
- `test_seed_sources_generate_order_items` — schema + count
- `test_seed_sources_daily_ids_are_unique` — IDs from consecutive days are disjoint

## Testing

```
9 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)