### PR TITLE
feat: add load-test mode to integration tests via job parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.15
     hooks:
     -   id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ---
 
-## [#27](https://github.com/andre-salvati/databricks-template/pull/27) · 2026-05-29 · feat: add load-test mode to integration tests via job parameter
+## [#28](https://github.com/andre-salvati/databricks-template/pull/28) · 2026-05-29 · feat: add load-test mode to integration tests via job parameter
 
 Added a `load_test` job parameter (default `"false"`) to the integration test job in both dev and staging. When set to `"true"`, the existing `Setup` and `Validate` tasks branch into load-test mode: `Setup` seeds 200 customers, 500k orders, and 200 order_items using `spark.range()` (distributed generation, no driver-side Python loops), and `Validate` checks that both `report.order_agg` and `report.order_agg_sdp` produce exactly 200 rows with the expected deterministic aggregates (`total_qty=2`, `total_value=50.0` per customer). The parameter is threaded from the job definition through `_wheel_task(include_load_test=True)` and stored in `Config.params` via the same `getattr` pattern used by `seed_date`. No new task classes or job definitions were added — the existing integration test job handles both modes. Added a `## Keep It Simple` principle to `CLAUDE.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## [#27](https://github.com/andre-salvati/databricks-template/pull/27) · 2026-05-29 · feat: add load-test mode to integration tests via job parameter
+
+Added a `load_test` job parameter (default `"false"`) to the integration test job in both dev and staging. When set to `"true"`, the existing `Setup` and `Validate` tasks branch into load-test mode: `Setup` seeds 200 customers, 500k orders, and 200 order_items using `spark.range()` (distributed generation, no driver-side Python loops), and `Validate` checks that both `report.order_agg` and `report.order_agg_sdp` produce exactly 200 rows with the expected deterministic aggregates (`total_qty=2`, `total_value=50.0` per customer). The parameter is threaded from the job definition through `_wheel_task(include_load_test=True)` and stored in `Config.params` via the same `getattr` pattern used by `seed_date`. No new task classes or job definitions were added — the existing integration test job handles both modes. Added a `## Keep It Simple` principle to `CLAUDE.md`.
+
+---
+
 ## [#26](https://github.com/andre-salvati/databricks-template/pull/26) · 2026-05-28 · refactor: convert SDP bronze tables to materialized_view, remove DQX from pipeline
 
 Converted all bronze table functions in `job1_sdp/pipeline.py` from `@dp.table` to `@dp.materialized_view` so Enzyme can track Delta version watermarks end-to-end without forcing full recomputes. Removed DQX from the SDP pipeline entirely because DQX's non-deterministic `run_time` timestamp caused Enzyme to treat annotated tables as changed on every run, propagating recomputes to all downstream materialized views. Data quality validation for order data is retained in the batch `job1`'s `ExtractSource2` task where DQX runs safely outside the incremental engine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,9 +156,12 @@ On every push: install deps → unit tests → bundle validate → deploy to sta
 - **Never commit directly to `main`.** All changes must go on a feature branch and land via PR. A hook blocks direct commits and pushes to `main`.
 - **Before merging a PR**, always update the PR description to accurately reflect all changes in the branch. Use `gh pr edit <number> --body "..."` to finalize it. A hook automatically uses the PR description as the merge commit message body, so whatever is in the description at merge time becomes the permanent commit record.
 
-## Don't
+## Keep It Simple
+
+Favor solutions with less code, fewer classes, and fewer abstractions. When two approaches both solve the problem, prefer the one with fewer moving parts — even if the "cleaner" architecture feels more elegant. Extend existing classes before creating new ones. Add a parameter before adding a new task key. Branch on a flag before splitting into subclasses.
 
 - Don't ship changes to the CLI surface (`main.py:arg_parser`), runtime env vars, catalog/schema model, or production guardrails without updating `README.md` and this file (`CLAUDE.md`) in the same commit. Stale docs are worse than no docs — they mislead future contributors and future sessions.
+- Don't merge a PR without adding an entry to `CHANGELOG.md` describing what changed and why.
 - Don't reintroduce `--user`, `--debug`, or `--schema` CLI args. They were removed deliberately — see PR #21.
 - Don't add `funcy` (or any decorator-based timing utility) to the dependencies. Use the structured logger.
 - Don't add `CREATE CATALOG` or `CREATE SCHEMA` calls outside the `args.env == "dev"` branch in `config.py`. Staging/prod catalogs and schemas are owned by `make init`; runtime jobs run without those privileges.

--- a/scripts/sdk_generate_template_job.py
+++ b/scripts/sdk_generate_template_job.py
@@ -99,19 +99,18 @@ def _get_service_principal_id(display_name: str, profile: str) -> int:
     raise ValueError(f"Service principal '{display_name}' not found in workspace.")
 
 
-def _wheel_task() -> PythonWheelTask:
-    return PythonWheelTask(
-        package_name="template",
-        entry_point="main",
-        parameters=[
-            "--task={{task.name}}",
-            "--env=${bundle.target}",
-            "--run-id={{job.run_id}}",
-            "--log-level={{job.parameters.log_level}}",
-            "--quarantine-fail-ratio={{job.parameters.quarantine_fail_ratio}}",
-            "--seed-date={{job.parameters.seed_date}}",
-        ],
-    )
+def _wheel_task(include_load_test: bool = False) -> PythonWheelTask:
+    params = [
+        "--task={{task.name}}",
+        "--env=${bundle.target}",
+        "--run-id={{job.run_id}}",
+        "--log-level={{job.parameters.log_level}}",
+        "--quarantine-fail-ratio={{job.parameters.quarantine_fail_ratio}}",
+        "--seed-date={{job.parameters.seed_date}}",
+    ]
+    if include_load_test:
+        params.append("--load-test={{job.parameters.load_test}}")
+    return PythonWheelTask(package_name="template", entry_point="main", parameters=params)
 
 
 def _environments() -> list[JobEnvironment]:
@@ -326,13 +325,15 @@ def _build_job_integration_test(environment: str, sp_id: str | None) -> dict:
     A single validate task waits for both run and run_sdp to finish, then checks
     both the batch output (report.order_agg) and the SDP output (report.order_agg_sdp).
     """
+    wheel = _wheel_task(include_load_test=True)
+
     tasks = [
         Task(
             task_key="setup",
             max_retries=0,
             timeout_seconds=TIMEOUT_INTEGRATION_S,
             environment_key="default",
-            python_wheel_task=_wheel_task(),
+            python_wheel_task=wheel,
         ),
         Task(
             task_key="run",
@@ -353,20 +354,23 @@ def _build_job_integration_test(environment: str, sp_id: str | None) -> dict:
             timeout_seconds=TIMEOUT_INTEGRATION_S,
             environment_key="default",
             depends_on=[TaskDependency(task_key="run"), TaskDependency(task_key="run_sdp")],
-            python_wheel_task=_wheel_task(),
+            python_wheel_task=wheel,
         ),
     ]
+
+    parameters = [
+        JobParameterDefinition(name="log_level", default=DEFAULT_LOG_LEVEL),
+        JobParameterDefinition(name="quarantine_fail_ratio", default=DEFAULT_QUARANTINE_FAIL_RATIO),
+        JobParameterDefinition(name="seed_date", default=""),
+    ]
+    parameters.append(JobParameterDefinition(name="load_test", default="false"))
 
     job = Job(
         name=f"{JOB_NAME}_${{bundle.target}}_integration_test",
         timeout_seconds=3600,
         max_concurrent_runs=1,
         queue=QueueSettings(enabled=True),
-        parameters=[
-            JobParameterDefinition(name="log_level", default=DEFAULT_LOG_LEVEL),
-            JobParameterDefinition(name="quarantine_fail_ratio", default=DEFAULT_QUARANTINE_FAIL_RATIO),
-            JobParameterDefinition(name="seed_date", default=""),
-        ],
+        parameters=parameters,
         tags=_tags(environment),
         environments=_environments(),
         tasks=tasks,

--- a/src/template/config.py
+++ b/src/template/config.py
@@ -64,6 +64,9 @@ class Config:
         seed_date = (getattr(args, "seed_date", None) or "").strip() or _date.today().isoformat()
         self.params.update({"seed_date": seed_date})
 
+        load_test = getattr(args, "load_test", "false") or "false"
+        self.params.update({"load_test": load_test})
+
         # run_id comes from --run-id={{job.run_id}}. Not exposed as an env var on serverless,
         # so it has to be threaded through as a CLI param. Falls back to "-" for local tests.
         run_id = getattr(args, "run_id", None) or "-"

--- a/src/template/main.py
+++ b/src/template/main.py
@@ -38,6 +38,8 @@ def arg_parser():
     # ISO-8601 date (YYYY-MM-DD). Empty string or absent → resolved to today by Config.
     # Filled by {{job.parameters.seed_date}}; override per-run for backfills.
     parser.add_argument("--seed-date", default=None)
+    # Staging-only: "true" activates load-test data volumes in Setup/Validate.
+    parser.add_argument("--load-test", default="false")
 
     return parser
 

--- a/tests/job1/integration_setup.py
+++ b/tests/job1/integration_setup.py
@@ -1,3 +1,6 @@
+from pyspark.sql import functions as F
+from pyspark.sql.types import FloatType, IntegerType
+
 from template.baseTask import BaseTask
 from template.commonSchemas import customer_schema, order_item_schema, order_schema
 from template.config import MEDALLION_SCHEMAS
@@ -9,11 +12,7 @@ class Setup(BaseTask):
     def __init__(self, config):
         super().__init__(config)
 
-    def run(self):
-        self.logger.info("setup for integration tests")
-
-        catalog = self.config.get_value("catalog")
-
+    def _reset_schemas(self, catalog):
         # Wipe all medallion schemas (including ops) so the integration test starts
         # from a clean slate. Re-create them immediately: on staging/prod, Config no
         # longer creates schemas at runtime, so Setup is responsible for restoring
@@ -23,13 +22,11 @@ class Setup(BaseTask):
         for s in MEDALLION_SCHEMAS:
             self.spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{s}")
 
-        # customer
-
+    def _seed_standard(self, catalog):
         customer_data = [(10, "John Doe", "USA"), (20, "Jane Smith", "UK")]
-        df_customer = self.spark.createDataFrame(customer_data, schema=customer_schema)
-        df_customer.write.saveAsTable(f"{catalog}.{SCHEMA}.customer")
-
-        # order
+        self.spark.createDataFrame(customer_data, schema=customer_schema).write.saveAsTable(
+            f"{catalog}.{SCHEMA}.customer"
+        )
 
         order_data = [
             (1, 10, 100.0, "2023-01-01"),
@@ -38,9 +35,46 @@ class Setup(BaseTask):
             (3, 20, 150.0, "2023-01-02"),  # id is duplicated
             (3, 20, 150.0, "2023-01-02"),
         ]  # id is duplicated
-        df_order = self.spark.createDataFrame(order_data, schema=order_schema)
-        df_order.write.saveAsTable(f"{catalog}.{SCHEMA}.order")
+        self.spark.createDataFrame(order_data, schema=order_schema).write.saveAsTable(f"{catalog}.{SCHEMA}.order")
 
         order_item_data = [(1, 1, "Item A", 2, 50.0), (1, 2, "Item B", 1, 50.0), (2, 1, "Item C", 3, 151.0)]
-        df_order_item = self.spark.createDataFrame(order_item_data, schema=order_item_schema)
-        df_order_item.write.saveAsTable(f"{catalog}.{SCHEMA}.order_item")
+        self.spark.createDataFrame(order_item_data, schema=order_item_schema).write.saveAsTable(
+            f"{catalog}.{SCHEMA}.order_item"
+        )
+
+    def _seed_load_test(self, catalog):
+        # 200 customers (ids 1–200)
+        self.spark.range(1, 201).select(
+            F.col("id").cast(IntegerType()),
+            F.concat(F.lit("Customer_"), F.col("id")).alias("name"),
+            F.lit("USA").alias("country"),
+        ).write.saveAsTable(f"{catalog}.{SCHEMA}.customer")
+
+        # 500k orders — customer_id round-robins through 1–200
+        self.spark.range(1, 500_001).select(
+            F.col("id").cast(IntegerType()),
+            ((F.col("id") - 1) % 200 + 1).cast(IntegerType()).alias("id_customer"),
+            F.lit(100.0).cast(FloatType()).alias("total"),
+            F.lit("2024-01-01").alias("date"),
+        ).write.saveAsTable(f"{catalog}.{SCHEMA}.order")
+
+        # 200 order_items — one item per order for orders 1–200
+        self.spark.range(1, 201).select(
+            F.col("id").cast(IntegerType()).alias("id_order"),
+            F.lit(1).cast(IntegerType()).alias("seq"),
+            F.concat(F.lit("Item_"), F.col("id")).alias("desc_item"),
+            F.lit(2).cast(IntegerType()).alias("qty"),
+            F.lit(50.0).cast(FloatType()).alias("total_item"),
+        ).write.saveAsTable(f"{catalog}.{SCHEMA}.order_item")
+
+    def run(self):
+        load_test = self.config.get_value("load_test") == "true"
+        self.logger.info("setup for integration tests (load_test=%s)", load_test)
+
+        catalog = self.config.get_value("catalog")
+        self._reset_schemas(catalog)
+
+        if load_test:
+            self._seed_load_test(catalog)
+        else:
+            self._seed_standard(catalog)

--- a/tests/job1/integration_validate.py
+++ b/tests/job1/integration_validate.py
@@ -1,3 +1,4 @@
+from pyspark.sql import functions as F
 from pyspark.sql.types import DoubleType, LongType, StringType, StructField, StructType
 from pyspark.testing import assertDataFrameEqual
 
@@ -8,15 +9,8 @@ class Validate(BaseTask):
     def __init__(self, config):
         super().__init__(config)
 
-    def run(self):
-        self.logger.info("validating integration tests")
-
-        catalog = self.config.get_value("catalog")
-
-        expected_data = [
-            ("John Doe", 3, 100.0),
-            ("Jane Smith", 3, 151.0),
-        ]
+    def _validate_standard(self, catalog):
+        expected_data = [("John Doe", 3, 100.0), ("Jane Smith", 3, 151.0)]
         expected_schema = StructType(
             [
                 StructField("name", StringType(), True),
@@ -32,3 +26,26 @@ class Validate(BaseTask):
             if count != 2:
                 raise RuntimeError(f"Expected 2 rows in {table}, got {count}")
             assertDataFrameEqual(df_out, df_expected)
+
+    def _validate_load_test(self, catalog):
+        # Each of the 200 customers has exactly 1 order_item (qty=2, total_item=50.0),
+        # so the aggregation must produce 200 rows with total_qty=2 and total_value=50.0.
+        for table in (f"{catalog}.report.order_agg", f"{catalog}.report.order_agg_sdp"):
+            df_out = self.spark.table(table)
+            count = df_out.count()
+            if count != 200:
+                raise RuntimeError(f"Expected 200 rows in {table}, got {count}")
+            wrong = df_out.filter((F.col("total_qty") != 2) | (F.col("total_value") != 50.0)).count()
+            if wrong > 0:
+                raise RuntimeError(f"{wrong} rows in {table} have unexpected total_qty/total_value")
+
+    def run(self):
+        load_test = self.config.get_value("load_test") == "true"
+        self.logger.info("validating integration tests (load_test=%s)", load_test)
+
+        catalog = self.config.get_value("catalog")
+
+        if load_test:
+            self._validate_load_test(catalog)
+        else:
+            self._validate_standard(catalog)

--- a/tests/job1/unit_test.py
+++ b/tests/job1/unit_test.py
@@ -83,7 +83,13 @@ def test_arg_parser():
     args = parser.parse_args(["--task=extract_source1", "--env=dev"])
 
     assert args == Namespace(
-        task="extract_source1", env="dev", run_id=None, log_level="INFO", quarantine_fail_ratio=1.0, seed_date=None
+        task="extract_source1",
+        env="dev",
+        run_id=None,
+        log_level="INFO",
+        quarantine_fail_ratio=1.0,
+        seed_date=None,
+        load_test="false",
     )
 
 
@@ -97,6 +103,7 @@ def test_arg_parser():
                 log_level="INFO",
                 quarantine_fail_ratio=1.0,
                 seed_date="2024-01-01",
+                load_test="false",
             ),
             {
                 "task": "extract_source1",
@@ -104,6 +111,7 @@ def test_arg_parser():
                 "log_level": "INFO",
                 "quarantine_fail_ratio": 1.0,
                 "seed_date": "2024-01-01",
+                "load_test": "false",
             },
         ),
     ],


### PR DESCRIPTION
## Summary

- Added `load_test` job parameter (default `"false"`) to the integration test job in both dev and staging; when set to `"true"`, the existing `Setup` and `Validate` tasks branch into load-test mode — no new classes or jobs added
- `Setup` load-test path seeds 200 customers, 500k orders, and 200 order_items via `spark.range()` (distributed generation, no driver-side Python loops)
- `Validate` load-test path checks both `report.order_agg` and `report.order_agg_sdp` for exactly 200 rows with deterministic aggregates (`total_qty=2`, `total_value=50.0` per customer)
- Parameter is threaded from the job definition through `_wheel_task(include_load_test=True)` and stored in `Config.params` via the same `getattr` pattern used by `seed_date`
- Added `## Keep It Simple` principle and CHANGELOG update rule to `CLAUDE.md`
- Fixed CHANGELOG entry PR number (#27 → #28)

## Test plan

- [x] `uv run pytest tests/` — all 9 unit tests pass
- [x] `make pre-commit` — ruff lint/format passes
- [x] `make deploy env=staging && make deploy env=dev` — both targets deploy cleanly
- [x] `make run env=staging` — standard integration test (`load_test=false`) passes end-to-end
- [ ] Manually trigger `job1_staging_integration_test` with `load_test=true` to exercise load-test volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)