### PR TITLE
feat: product dimensions, seed enrichment, truncate script, prod schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [#30](https://github.com/andre-salvati/databricks-template/pull/30) · 2026-06-03 · feat: product dimensions, seed enrichment, truncate script, prod schedule
+
+Added `product_id` (100 distinct) and `prod_category_id` (10 distinct) to the order schema and propagated them through extract → enrich → aggregate → SDP transforms; `report.order_agg` now groups by `name`, `date`, `product_id`, `prod_category_id`.
+Enriched seed data: 2M orders spread over 365 days with varied totals ($10–$990), 10 countries, 500 customers, 5 000 incremental orders/day; raised DQX WARN limit to 1 000 to match the new range.
+Added `scripts/sdk_truncate_tables.py` (with `make truncate env=X yes=--yes`) and `scripts/_sdk_sql.py` (shared `get_warehouse_id`/`run_sql` helpers extracted from `sdk_init_workspace.py`).
+Added a 6 am BRT daily cron schedule to `job1_prod_integration`.
+
+---
+
 ## [#29](https://github.com/andre-salvati/databricks-template/pull/29) · 2026-05-29 · feat: scale load-test, rewrite seed_sources, add prod integration job
 
 Scaled load-test to 500 customers / 2M orders / 6M order_items so the batch vs incremental timing gap is measurable; updated `_validate_load_test` assertions accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ## [#29](https://github.com/andre-salvati/databricks-template/pull/29) · 2026-05-29 · feat: scale load-test, rewrite seed_sources, add prod integration job
 
-Scaled load-test seed volumes from 200 customers / 500k orders / 200 order_items to 500 customers / 2M orders / 6M order_items (3 items per order) so the 3-way join in `GenerateOrders` is genuinely heavy and the batch vs incremental timing gap is measurable. Updated `_validate_load_test` assertions accordingly (500 rows, `total_qty=24_000`, `total_value=600_000.0`). Rewrote `seed_sources` with a two-phase design: when `external_source.customer` has fewer than 500 rows it performs a full initial load via `spark.range()`; on every subsequent run it appends 2000 new orders and 2000 order_items via `.write.mode("append")` and MERGEs `country` updates for 50 customers (cycling through all 500 every 10 days). Incremental orders and items use append (not MERGE) since IDs are unique per date. Logs `external_source` row totals after every run. Added `job1_prod_integration` job — `seed_sources` → (`run` + `run_sdp` in parallel), no validate — mirroring the staging integration test pattern; `seed_sources` removed from `job1_prod`'s task graph so the prod ETL job is now structurally identical to staging (`health_check` → extracts → transforms). Updated unit tests to use the new `_build_incremental_*` builder methods.
+Scaled load-test to 500 customers / 2M orders / 6M order_items so the batch vs incremental timing gap is measurable; updated `_validate_load_test` assertions accordingly.
+Rewrote `seed_sources`: initial load when `customer` count < 500, then daily append of 2000 orders + items and MERGE of 50 customer country updates; logs table totals after each run.
+Added `job1_prod_integration` job (seed → run + run_sdp in parallel, no validate); removed `seed_sources` from `job1_prod` so the prod ETL is structurally identical to staging.
 
 ---
 
 ## [#28](https://github.com/andre-salvati/databricks-template/pull/28) · 2026-05-29 · feat: add load-test mode to integration tests via job parameter
 
-Added a `load_test` job parameter (default `"false"`) to the integration test job in both dev and staging. When set to `"true"`, the existing `Setup` and `Validate` tasks branch into load-test mode: `Setup` seeds 200 customers, 500k orders, and 200 order_items using `spark.range()` (distributed generation, no driver-side Python loops), and `Validate` checks that both `report.order_agg` and `report.order_agg_sdp` produce exactly 200 rows with the expected deterministic aggregates (`total_qty=2`, `total_value=50.0` per customer). The parameter is threaded from the job definition through `_wheel_task(include_load_test=True)` and stored in `Config.params` via the same `getattr` pattern used by `seed_date`. No new task classes or job definitions were added — the existing integration test job handles both modes. Added a `## Keep It Simple` principle to `CLAUDE.md`.
+Added a `load_test` job parameter (default `"false"`) to the integration test job.
+When `"true"`, `Setup` seeds 200 customers / 500k orders / 200 order_items via `spark.range()` and `Validate` checks both `report.order_agg` and `report.order_agg_sdp` for deterministic aggregates.
+No new task classes — the existing integration test job handles both modes.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A production-ready PySpark/Databricks ETL pipeline template using medallion arch
 
 This project is developed with the [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit) installed at the user level (`~/.ai-dev-kit/`). It provides:
 
-- **Databricks MCP server** (`mcp__databricks__*` tools) — wired globally in `~/.claude.json`, authenticates via the `DEFAULT` profile in `~/.databrickscfg`.
+- **Databricks MCP server** (`mcp__databricks__*` tools) — wired globally in `~/.claude.json`, authenticates via the `dev` profile in `~/.databrickscfg`.
 - **Databricks skills** (`databricks-bundles`, `databricks-jobs`, `databricks-python-sdk`, `databricks-config`, `databricks-unity-catalog`, etc.) — invoke via the Skill tool when the task matches.
 
 ### When to use what
@@ -23,7 +23,7 @@ This project is developed with the [Databricks AI Dev Kit](https://github.com/da
 
 ### Conventions
 
-- Use the `DEFAULT` profile unless told otherwise. To check or switch, use the `databricks-config` skill.
+- Use the `dev` profile unless told otherwise. To check or switch, use the `databricks-config` skill.
 - Do **not** install the Dev Kit into this repo or commit MCP config — it's a user-level tool. `.claude/` is currently untracked.
 - If MCP tools are unavailable in a session, fall back to the `databricks` CLI or `databricks-sdk` directly, but flag it to the user.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 env ?= dev
+yes ?=
 
 sync:
 	uv sync --all-extras
@@ -28,4 +29,7 @@ deploy: whoami
 
 run: whoami
 	uv run databricks bundle run job1_integration_test --target $(env)
+
+truncate: whoami
+	uv run python ./scripts/sdk_truncate_tables.py $(env) $(yes)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# databricks-template — production-ready ETL + agentic development for Databricks
-
-> A PySpark project template for Databricks built for both human and AI-assisted (agentic) development. Medallion architecture, Python packaging, unit + integration tests, CI/CD via Declarative Automation Bundles, DQX data quality, service-principal-based production deploys — and a curated [`CLAUDE.md`](CLAUDE.md) so AI assistants understand the project's conventions on the first session.
+# databricks-template — agentic development for Databricks + production-ready ETL
 
 ![Databricks](https://img.shields.io/badge/platform-Databricks-orange?logo=databricks)
 ![PySpark](https://img.shields.io/badge/pyspark-4.1+-brightgreen?logo=apache-spark)
@@ -10,11 +8,9 @@
 
 ## 🚀 Overview
 
-This project template is designed to boost productivity and promote maintainability when developing ETL pipelines on Databricks. It is **built for agentic development** and brings software engineering best practices—modular architecture, automated unit and integration testing, CI/CD, structured logging, service-principal-based production guardrails—into the world of data engineering. By combining a clean project structure with robust development and deployment jobs, it helps teams move faster with confidence.
+> Stop spending weeks on boilerplate. This PySpark project template for Databricks gives you medallion architecture, Python packaging, unit + integration + load tests, CI/CD via Declarative Automation Bundles, DQX data quality, and service-principal-based production deploys — all wired together and ready to ship. Whether you're starting a new Databricks ETL project or looking for a reference implementation of production-ready PySpark pipelines, fork this and go.
 
-You're encouraged to adapt the structure and tooling to suit your project's specific needs and environment.
-
-Let's [connect on LinkedIn](https://www.linkedin.com/in/andresalvati/).
+If this saves you time, a star helps others find it. Let's [connect on LinkedIn](https://www.linkedin.com/in/andresalvati/).
 
 ## 🧪 Technologies
 
@@ -37,26 +33,28 @@ Let's [connect on LinkedIn](https://www.linkedin.com/in/andresalvati/).
 
 This project template demonstrates how to:
 
-- use agentic development (with Databricks AI Dev Kit and Claude Code) in data projects. The template ships with a [`CLAUDE.md`](CLAUDE.md) that documents the project's conventions — CLI surface, catalog/schema model, runtime parameters, production guardrails, and a *constraints* section recording the gotchas we've hit. Design decisions made in collaboration with the agent are encoded as rules in `CLAUDE.md` so they survive across sessions.
-- structure PySpark code inside classes/packages and utilize a Python wheel package, instead of notebooks.
-- package and deploy code with [Declarative Automation Bundles](https://docs.databricks.com/en/dev-tools/bundles/index.html) to different environments (dev, staging, prod). Use a CI/CD pipeline with [GitHub Actions](https://docs.github.com/en/actions). Generate job definitions to run with environment-specific conditions using [Databricks SDK](https://docs.databricks.com/aws/en/dev-tools/sdk-python#create-a-job-that-uses-serverless-compute).
+- use agentic development (with Databricks AI Dev Kit and Claude Code) in data projects. The template ships with a [`CLAUDE.md`](CLAUDE.md) that documents the project's conventions.
+- structure PySpark code inside classes/packages, deploy it as a Python wheel (instead of notebooks), and manage the project with [uv](https://docs.astral.sh/uv/).
+- package and deploy code with [Declarative Automation Bundles](https://docs.databricks.com/en/dev-tools/bundles/index.html) to different environments (dev, staging, prod). Use [GitHub Actions](https://docs.github.com/en/actions) to automate CI/CD pipeline. 
+- utilize [Databricks Lakeflow Jobs](https://docs.databricks.com/en/workflows/index.html) to execute a DAG - Yes, you don't need Airflow to manage your DAGs here!!!. Generate job definitions to run with environment-specific conditions using [Databricks SDK](https://docs.databricks.com/aws/en/dev-tools/sdk-python#create-a-job-that-uses-serverless-compute).
 - isolate "dev" environments / catalogs to avoid concurrency issues between developer tests.
-- ships with a twin [Lakeflow Spark Declarative Pipeline](https://docs.databricks.com/aws/en/ldp/) that runs the same ETL logic side-by-side with the batch job, demonstrating both paradigms from one codebase.
+- separate deploy-time config (environment variables, CI secrets) from runtime config (job parameters overridable from the Databricks UI), keeping jobs flexible without coupling them to the build process.
+- utilize job tags to track issues, costs, and ownership.
+- use a [Lakeflow Spark Declarative Pipeline](https://docs.databricks.com/aws/en/ldp/) to run the same ETL logic side-by-side with the PySpark job, demonstrating both paradigms from one codebase.
+- use the [medallion architecture](https://www.databricks.com/glossary/medallion-architecture) to organize your data.
 - run unit tests on transformations with the [pytest package](https://pypi.org/project/pytest/). Set up VS Code to run tests on your local machine.
 - run integration tests by setting the input data and validating the output data.
-- utilize job tags to track issues, costs, and ownership.
+- run load tests to exercise both the initial bulk load and incremental daily updates, validating that the pipeline handles production-scale data volumes without regressions.
 - utilize the [coverage package](https://pypi.org/project/coverage/) to generate test coverage reports.
-- utilize [uv](https://docs.astral.sh/uv/) as a project/package manager.
-- use the [medallion architecture](https://www.databricks.com/glossary/medallion-architecture) pattern.
+- use structured logging with a per-run `log_level` override and run-scoped correlation ID on every line, giving you full observability during incidents without a code change.
 - lint and format code with [ruff](https://docs.astral.sh/ruff/) and [pre-commit](https://pre-commit.com/).
 - use a Makefile to automate repetitive tasks.
-- utilize the [argparse package](https://pypi.org/project/argparse/) to build a flexible command-line interface to start the jobs.
 - utilize [Databricks DQX](https://databrickslabs.github.io/dqx/) to enforce data quality rules, such as null checks, uniqueness, thresholds, and schema validation, and filter bad data into quarantine tables.
 - utilize [service principals](https://docs.databricks.com/aws/en/admin/users-groups/service-principals) to run production code.
-- utilize the [Databricks SDK for Python](https://docs.databricks.com/en/dev-tools/sdk-python.html) to manage workspaces and accounts and analyze costs. Refer to the `scripts` folder for examples.
+- utilize the [Databricks SDK for Python](https://docs.databricks.com/en/dev-tools/sdk-python.html) to manage catalogs, schemas, workspaces, and accounts. Refer to the `scripts` folder for examples.
 - utilize [Databricks Unity Catalog](https://www.databricks.com/product/unity-catalog) to manage permissions and get data lineage.
-- utilize [Databricks Lakeflow Jobs](https://docs.databricks.com/en/workflows/index.html) to execute a DAG. Yes, you don't need Airflow to manage your DAGs here!!!
 - utilize serverless job clusters on [Databricks Free Edition](https://docs.databricks.com/aws/en/getting-started/free-edition) to deploy your pipelines.
+- enforce production guardrails out of the box — identity-locked CI deploys, a health-check task that runs before any data is touched, wheel version pinning, per-task timeouts, schema-drift guards, queued runs, and on-call alerting that doesn't page on manual cancellations.
 
 ## 🧠 Resources
 
@@ -98,20 +96,20 @@ databricks-template/
 │       ├── config.py              # Configuration management
 │       ├── baseTask.py            # Base class for all tasks
 │       ├── commonSchemas.py       # Shared PySpark schemas
-│       ├── job1/                  # Job-specific tasks
-│       │   ├── extract_source1.py
-│       │   ├── extract_source2.py        # DQX validation + quarantine
-│       │   ├── generate_orders.py
-│       │   ├── generate_orders_agg.py
-│       │   ├── health_check.py           # Prod smoke task (runs first)
-│       │   ├── integration_setup.py
-│       │   └── integration_validate.py
-│       └── job2/                  # Additional job tasks
+│       └── job1/                  # Job-specific tasks
+│           ├── extract_source1.py
+│           ├── extract_source2.py        # DQX validation + quarantine
+│           ├── generate_orders.py
+│           ├── generate_orders_agg.py
+│           ├── health_check.py           # Prod smoke task (runs first)
+│           └── seed_sources.py           # Idempotent daily seeder (prod integration)
 │
-├── tests/                          # Unit tests
-│   ├── job1/
-│   │   └── unit_test.py            # Pytest unit tests
-│   └── job2/
+├── tests/                          # Unit and integration tests
+│   └── job1/
+│       ├── unit_test.py            # Pytest unit tests
+│       ├── unit_test_sdp.py        # SDP pipeline unit tests
+│       ├── integration_setup.py    # Integration test setup (seed data)
+│       └── integration_validate.py # Integration test validation
 │
 ├── resources/                      # Databricks workflow templates
 │   └── jobs.yml                    # Generated job definition (auto-created)
@@ -119,8 +117,10 @@ databricks-template/
 ├── scripts/                              # Helper scripts
 │   ├── sdk_generate_template_job.py      # Job definition generator (Databricks SDK)
 │   ├── sdk_init_workspace.py             # Workspace initialization (SP, catalogs, schemas, grants)
+│   ├── sdk_truncate_tables.py            # Truncate all medallion tables in a target environment
 │   ├── sdk_analyze_job_costs.py          # Cost analysis script
-│   └── sdk_workspace_and_account.py      # Workspace and account management
+│   ├── sdk_workspace_and_account.py      # Workspace and account management
+│   └── _sdk_sql.py                       # SQL warehouse helpers (used by other scripts)
 │
 ├── docs/                           # Documentation assets
 │   ├── dag.png
@@ -139,7 +139,7 @@ databricks-template/
 └── README.md                    # This file
 ```
 
-## CI/CD pipeline
+## Development Lifecycle
 
 <br>
 
@@ -155,7 +155,7 @@ databricks-template/
 
 <br>
 
-## Task Output
+## Logging
 
 <br>
 
@@ -183,7 +183,6 @@ databricks-template/
 
 ## Instructions
 
-
 1) (Optional) Install [Databricks AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit) and [Claude Code](https://code.claude.com/docs/en/vs-code).
 
 2) Create a [Databricks Free Edition](https://docs.databricks.com/aws/en/getting-started/free-edition) workspace.
@@ -196,7 +195,8 @@ databricks-template/
 
         make sync && make test
         
-5) Initialize the workspace. Create an external location in Databricks and update the `storage-root` parameter in the Makefile. This step will create the catalogs, schemas, service principal, and the required grants. For more details, see [Overview of external locations](https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage#external-locations). Then run:
+5) Initialize the workspace. Create an external location in Databricks and update the `storage-root` parameter in the Makefile. This step will create the catalogs, schemas, service principal, and the required grants. For more details, see [Overview of external locations](https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage#external-locations). Then 
+run:
 
         make init
 
@@ -219,7 +219,7 @@ databricks-template/
 7) Deploy and execute on the dev workspace.
 
         make deploy env=dev
-
+ Deploy-time environment variables (
 
 8) Configure CI/CD automation with the service principal ID and secret. Configure [GitHub Actions repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) (DATABRICKS_HOST, DATABRICKS_PRINCIPAL_ID, DATABRICKS_SECRET).
 

--- a/scripts/_sdk_sql.py
+++ b/scripts/_sdk_sql.py
@@ -1,0 +1,41 @@
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import StatementState
+
+
+def get_warehouse_id(workspace: WorkspaceClient, name: str | None = None) -> str:
+    """Resolve a SQL warehouse to use for DDL.
+
+    Picking warehouses[0] is fragile — the API returns warehouses in an
+    implementation-defined order, so on a workspace with multiple warehouses
+    we'd silently grab whichever one happens to be first. Instead:
+
+    - If `name` is provided, look it up by name (fail loudly if missing).
+    - Otherwise, succeed only if there's exactly one warehouse; fail with
+      a clear "ambiguous, pass --warehouse-name" error when there are many.
+    """
+    warehouses = list(workspace.warehouses.list())
+    if not warehouses:
+        raise ValueError("No SQL warehouse found. Please create one to run SQL statements.")
+
+    if name:
+        match = next((w for w in warehouses if w.name == name), None)
+        if match is None:
+            raise ValueError(f"SQL warehouse {name!r} not found. Available: {[w.name for w in warehouses]}")
+        return match.id
+
+    if len(warehouses) > 1:
+        raise ValueError(
+            f"Multiple SQL warehouses found ({[w.name for w in warehouses]}); pass --warehouse-name to disambiguate."
+        )
+    return warehouses[0].id
+
+
+def run_sql(workspace: WorkspaceClient, warehouse_id: str, sql: str) -> None:
+    print(f"  Running: {sql}")
+    result = workspace.statement_execution.execute_statement(
+        warehouse_id=warehouse_id,
+        statement=sql,
+        wait_timeout="50s",
+    )
+    if result.status.state != StatementState.SUCCEEDED:
+        raise RuntimeError(f"Statement failed ({result.status.state}): {result.status.error}")

--- a/scripts/sdk_generate_template_job.py
+++ b/scripts/sdk_generate_template_job.py
@@ -410,6 +410,10 @@ def _build_job_prod_integration(sp_id: str | None) -> dict:
             no_alert_for_canceled_runs=True,
             no_alert_for_skipped_runs=True,
         ),
+        schedule=CronSchedule(
+            quartz_cron_expression="0 0 6 * * ?",
+            timezone_id="America/Sao_Paulo",
+        ),
         parameters=[
             JobParameterDefinition(name="log_level", default=DEFAULT_LOG_LEVEL),
             JobParameterDefinition(name="quarantine_fail_ratio", default=PROD_QUARANTINE_FAIL_RATIO),

--- a/scripts/sdk_init_workspace.py
+++ b/scripts/sdk_init_workspace.py
@@ -2,7 +2,8 @@ import argparse
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.iam import AccessControlRequest, PermissionLevel
-from databricks.sdk.service.sql import StatementState
+
+from _sdk_sql import get_warehouse_id, run_sql
 
 
 SP_DISPLAY_NAME = "template-sp"
@@ -13,45 +14,6 @@ CATALOGS = ["staging", "prod"]
 # Keep aligned with template.config.MEDALLION_SCHEMAS so staging/prod come up with
 # the same schema layout that dev creates on the fly.
 SCHEMAS = ["external_source", "raw", "curated", "report", "ops"]
-
-
-def _get_warehouse_id(workspace: WorkspaceClient, name: str | None = None) -> str:
-    """Resolve a SQL warehouse to use for DDL.
-
-    Picking warehouses[0] is fragile — the API returns warehouses in an
-    implementation-defined order, so on a workspace with multiple warehouses
-    we'd silently grab whichever one happens to be first. Instead:
-
-    - If `name` is provided, look it up by name (fail loudly if missing).
-    - Otherwise, succeed only if there's exactly one warehouse; fail with
-      a clear "ambiguous, pass --warehouse-name" error when there are many.
-    """
-    warehouses = list(workspace.warehouses.list())
-    if not warehouses:
-        raise ValueError("No SQL warehouse found. Please create one to run SQL statements.")
-
-    if name:
-        match = next((w for w in warehouses if w.name == name), None)
-        if match is None:
-            raise ValueError(f"SQL warehouse {name!r} not found. Available: {[w.name for w in warehouses]}")
-        return match.id
-
-    if len(warehouses) > 1:
-        raise ValueError(
-            f"Multiple SQL warehouses found ({[w.name for w in warehouses]}); pass --warehouse-name to disambiguate."
-        )
-    return warehouses[0].id
-
-
-def _run_sql(workspace: WorkspaceClient, warehouse_id: str, sql: str):
-    print(f"  Running: {sql}")
-    result = workspace.statement_execution.execute_statement(
-        warehouse_id=warehouse_id,
-        statement=sql,
-        wait_timeout="50s",
-    )
-    if result.status.state != StatementState.SUCCEEDED:
-        raise RuntimeError(f"Statement failed ({result.status.state}): {result.status.error}")
 
 
 # --- Service principal ---
@@ -93,7 +55,7 @@ def create_service_principal(workspace: WorkspaceClient, display_name: str, ware
     except Exception as e:
         print(f"  Warning: could not set CAN_USE on service principal ({e}). Continuing.")
 
-    _run_sql(workspace, warehouse_id, f"GRANT CREATE CATALOG ON Metastore TO `{sp_id}`")
+    run_sql(workspace, warehouse_id, f"GRANT CREATE CATALOG ON Metastore TO `{sp_id}`")
 
     print(f"\nSP_ID={sp_id}")
     return sp_id
@@ -124,7 +86,7 @@ def create_catalogs_and_schemas(workspace: WorkspaceClient, sp_id: str, storage_
             workspace.catalogs.create(**kwargs)
             print(f"  Created catalog '{catalog}'.")
 
-        _run_sql(workspace, warehouse_id, f"GRANT ALL PRIVILEGES ON CATALOG `{catalog}` TO `{sp_id}`")
+        run_sql(workspace, warehouse_id, f"GRANT ALL PRIVILEGES ON CATALOG `{catalog}` TO `{sp_id}`")
 
         existing_schs = _existing_schemas(workspace, catalog)
         for schema in SCHEMAS:
@@ -133,7 +95,7 @@ def create_catalogs_and_schemas(workspace: WorkspaceClient, sp_id: str, storage_
             else:
                 workspace.schemas.create(name=schema, catalog_name=catalog)
                 print(f"    Created schema '{catalog}.{schema}'.")
-            _run_sql(workspace, warehouse_id, f"GRANT MANAGE ON SCHEMA `{catalog}`.`{schema}` TO `{sp_id}`")
+            run_sql(workspace, warehouse_id, f"GRANT MANAGE ON SCHEMA `{catalog}`.`{schema}` TO `{sp_id}`")
 
 
 # --- Entry point ---
@@ -168,7 +130,7 @@ def main():
     workspace = WorkspaceClient(profile=args.profile)
     # Resolve once up-front so a missing/ambiguous warehouse fails before we
     # create any SP or catalogs.
-    warehouse_id = _get_warehouse_id(workspace, args.warehouse_name)
+    warehouse_id = get_warehouse_id(workspace, args.warehouse_name)
     print(f"Using SQL warehouse: {warehouse_id}")
 
     print("\n=== Step 1: Service principal ===")

--- a/scripts/sdk_truncate_tables.py
+++ b/scripts/sdk_truncate_tables.py
@@ -5,10 +5,9 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import TableType
 
 from _sdk_sql import get_warehouse_id, run_sql
+from template.config import MEDALLION_SCHEMAS
 
 _TRUNCATABLE = {TableType.MANAGED, TableType.EXTERNAL}
-
-SCHEMAS = ["external_source", "raw", "curated", "report", "ops"]
 
 
 def _resolve_catalog(workspace: WorkspaceClient, env: str) -> str:
@@ -40,7 +39,7 @@ def main():
 
     print(f"Truncating all tables in catalog '{catalog}'...")
     count = 0
-    for schema in SCHEMAS:
+    for schema in MEDALLION_SCHEMAS:
         for table in workspace.tables.list(catalog_name=catalog, schema_name=schema):
             if table.table_type not in _TRUNCATABLE:
                 print(f"  Skipping `{catalog}`.`{schema}`.`{table.name}` ({table.table_type})")

--- a/scripts/sdk_truncate_tables.py
+++ b/scripts/sdk_truncate_tables.py
@@ -1,0 +1,55 @@
+import argparse
+import re
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.catalog import TableType
+
+from _sdk_sql import get_warehouse_id, run_sql
+
+_TRUNCATABLE = {TableType.MANAGED, TableType.EXTERNAL}
+
+SCHEMAS = ["external_source", "raw", "curated", "report", "ops"]
+
+
+def _resolve_catalog(workspace: WorkspaceClient, env: str) -> str:
+    if env == "dev":
+        local_part = workspace.current_user.me().user_name.split("@")[0]
+        user = re.sub(r"[^a-zA-Z0-9_]", "_", local_part)
+        return f"dev_{user}"
+    return env
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Truncate all medallion tables in a target environment.")
+    parser.add_argument("env", choices=["dev", "staging", "prod"])
+    parser.add_argument("--yes", "-y", action="store_true", help="Confirm truncation (required for staging/prod).")
+    parser.add_argument(
+        "--warehouse-name",
+        default=None,
+        help="SQL warehouse name to use. Required when the workspace has multiple warehouses.",
+    )
+    args = parser.parse_args()
+
+    if args.env in ("staging", "prod") and not args.yes:
+        print(f"This will truncate ALL tables in '{args.env}'. Pass --yes to confirm.")
+        raise SystemExit(1)
+
+    workspace = WorkspaceClient(profile=args.env)
+    warehouse_id = get_warehouse_id(workspace, args.warehouse_name)
+    catalog = _resolve_catalog(workspace, args.env)
+
+    print(f"Truncating all tables in catalog '{catalog}'...")
+    count = 0
+    for schema in SCHEMAS:
+        for table in workspace.tables.list(catalog_name=catalog, schema_name=schema):
+            if table.table_type not in _TRUNCATABLE:
+                print(f"  Skipping `{catalog}`.`{schema}`.`{table.name}` ({table.table_type})")
+                continue
+            run_sql(workspace, warehouse_id, f"TRUNCATE TABLE `{catalog}`.`{schema}`.`{table.name}`")
+            count += 1
+
+    print(f"Done. {count} table(s) truncated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/template/commonSchemas.py
+++ b/src/template/commonSchemas.py
@@ -20,6 +20,8 @@ order_schema = StructType(
         StructField("id_customer", IntegerType(), True),
         StructField("total", FloatType(), True),
         StructField("date", StringType(), True),
+        StructField("product_id", IntegerType(), True),
+        StructField("prod_category_id", IntegerType(), True),
     ]
 )
 

--- a/src/template/job1/extract_source2.py
+++ b/src/template/job1/extract_source2.py
@@ -15,11 +15,11 @@ class ExtractSource2(BaseTask):
 
     def validate_order(self, df_order):
         checks = [
-            # Warning if total > 150
+            # Warning if total > 1000
             DQRowRule(
                 column="total",
                 check_func=check_funcs.is_not_greater_than,
-                check_func_kwargs={"limit": 150},
+                check_func_kwargs={"limit": 1000},
                 criticality=Criticality.WARN.value,
             ),
             # Error if ids are not null or empty

--- a/src/template/job1/generate_orders.py
+++ b/src/template/job1/generate_orders.py
@@ -11,7 +11,19 @@ class GenerateOrders(BaseTask):
         return (
             df_order_item.join(df_order, df_order_item["id_order"] == df_order["id"])
             .join(df_customer, df_order["id_customer"] == df_customer["id"])
-            .select("name", "id_customer", "id_order", "total", "seq", "desc_item", "qty", "total_item")
+            .select(
+                "name",
+                "id_customer",
+                "id_order",
+                "total",
+                "date",
+                "product_id",
+                "prod_category_id",
+                "seq",
+                "desc_item",
+                "qty",
+                "total_item",
+            )
         )
 
     def run(self):

--- a/src/template/job1/generate_orders_agg.py
+++ b/src/template/job1/generate_orders_agg.py
@@ -10,7 +10,10 @@ class GenerateOrdersAgg(BaseTask):
     def aggregate_orders(self, df_order):
         # TODO code your transformations here...
 
-        return df_order.groupBy("name").agg(sum("qty").alias("total_qty"), sum("total_item").alias("total_value"))
+        return df_order.groupBy("name", "date", "product_id", "prod_category_id").agg(
+            sum("qty").alias("total_qty"),
+            sum("total_item").alias("total_value"),
+        )
 
     def run(self):
         self.logger.info("generating orders aggregated")

--- a/src/template/job1/seed_sources.py
+++ b/src/template/job1/seed_sources.py
@@ -24,7 +24,7 @@ class SeedSources(BaseTask):
     Idempotent seeder for external_source tables.
 
     First run (empty tables): full initial load — 500 customers, 2M orders, 6M order_items.
-    Subsequent runs: append 2000 orders (+1 item each) and update 50 customers' country.
+    Subsequent runs: append 5 000 orders (+1 item each) and update 50 customers' country.
     Incremental IDs are anchored to seed_date so reruns of the same date are no-ops.
     """
 

--- a/src/template/job1/seed_sources.py
+++ b/src/template/job1/seed_sources.py
@@ -9,13 +9,13 @@ from ..commonSchemas import customer_schema, order_item_schema, order_schema
 SCHEMA = "external_source"
 
 _EPOCH = _date(2024, 1, 1)
-_COUNTRIES = ["US", "UK", "CA", "DE", "FR"]
+_COUNTRIES = ["US", "UK", "CA", "DE", "FR", "BR", "AU", "JP", "MX", "IN"]
 
 _INITIAL_CUSTOMERS = 500
 _INITIAL_ORDERS = 2_000_000
 _INITIAL_ITEMS = 6_000_000  # 3 per order
 
-_INCREMENTAL_ORDERS = 2_000
+_INCREMENTAL_ORDERS = 5_000
 _INCREMENTAL_CUSTOMER_UPDATES = 50
 
 
@@ -42,7 +42,7 @@ class SeedSources(BaseTask):
                 _INITIAL_ORDERS,
                 _INITIAL_ITEMS,
             )
-            self._seed_initial(catalog)
+            self._seed_initial(catalog, seed_date)
             self.logger.info("initial load complete")
         else:
             self.logger.info("incremental seed date=%s", seed_date)
@@ -71,18 +71,23 @@ class SeedSources(BaseTask):
     # Initial load (first run only)
     # ------------------------------------------------------------------
 
-    def _seed_initial(self, catalog: str) -> None:
+    def _seed_initial(self, catalog: str, seed_date: str) -> None:
         self.spark.range(1, _INITIAL_CUSTOMERS + 1).select(
             F.col("id").cast(IntegerType()),
             F.concat(F.lit("Customer_"), F.col("id")).alias("name"),
-            F.lit("US").alias("country"),
+            F.element_at(
+                F.array(*[F.lit(c) for c in _COUNTRIES]),
+                (F.col("id") % len(_COUNTRIES)).cast(IntegerType()) + 1,
+            ).alias("country"),
         ).write.mode("overwrite").option("overwriteSchema", "false").saveAsTable(f"{catalog}.{SCHEMA}.customer")
 
         self.spark.range(1, _INITIAL_ORDERS + 1).select(
             F.col("id").cast(IntegerType()),
             ((F.col("id") - 1) % _INITIAL_CUSTOMERS + 1).cast(IntegerType()).alias("id_customer"),
-            F.lit(100.0).cast(FloatType()).alias("total"),
-            F.lit("2024-01-01").alias("date"),
+            ((F.col("id") % 99 + 1) * 10).cast(FloatType()).alias("total"),
+            F.date_sub(F.lit(seed_date), (F.col("id") % 365).cast(IntegerType())).cast("string").alias("date"),
+            (F.col("id") % 100 + 1).cast(IntegerType()).alias("product_id"),
+            (F.col("id") % 10 + 1).cast(IntegerType()).alias("prod_category_id"),
         ).write.mode("overwrite").option("overwriteSchema", "false").saveAsTable(f"{catalog}.{SCHEMA}.order")
 
         self.spark.range(1, _INITIAL_ITEMS + 1).select(
@@ -130,8 +135,10 @@ class SeedSources(BaseTask):
         return self.spark.range(order_base + 1, order_base + _INCREMENTAL_ORDERS + 1).select(
             F.col("id").cast(IntegerType()),
             ((F.col("id") - 1) % _INITIAL_CUSTOMERS + 1).cast(IntegerType()).alias("id_customer"),
-            F.lit(100.0).cast(FloatType()).alias("total"),
+            ((F.col("id") % 99 + 1) * 10).cast(FloatType()).alias("total"),
             F.lit(seed_date).alias("date"),
+            (F.col("id") % 100 + 1).cast(IntegerType()).alias("product_id"),
+            (F.col("id") % 10 + 1).cast(IntegerType()).alias("prod_category_id"),
         )
 
     def _build_incremental_items(self, seed_date: str):

--- a/src/template/job1_sdp/transforms.py
+++ b/src/template/job1_sdp/transforms.py
@@ -26,12 +26,24 @@ def enrich_order(df_customer: DataFrame, df_order: DataFrame, df_order_item: Dat
 
     Returns:
         Enriched DataFrame with columns:
-        name, id_customer, id_order, total, seq, desc_item, qty, total_item
+        name, id_customer, id_order, total, date, product_id, prod_category_id, seq, desc_item, qty, total_item
     """
     return (
         df_order_item.join(df_order, df_order_item["id_order"] == df_order["id"])
         .join(df_customer, df_order["id_customer"] == df_customer["id"])
-        .select("name", "id_customer", "id_order", "total", "seq", "desc_item", "qty", "total_item")
+        .select(
+            "name",
+            "id_customer",
+            "id_order",
+            "total",
+            "date",
+            "product_id",
+            "prod_category_id",
+            "seq",
+            "desc_item",
+            "qty",
+            "total_item",
+        )
     )
 
 
@@ -45,9 +57,9 @@ def aggregate_orders(df_order_enriched: DataFrame) -> DataFrame:
         df_order_enriched: curated.order_enriched
 
     Returns:
-        DataFrame with columns: name, total_qty (LongType), total_value (DoubleType)
+        DataFrame with columns: name, date, product_id, prod_category_id, total_qty (LongType), total_value (DoubleType)
     """
-    return df_order_enriched.groupBy("name").agg(
+    return df_order_enriched.groupBy("name", "date", "product_id", "prod_category_id").agg(
         F.sum("qty").alias("total_qty"),
         F.sum("total_item").alias("total_value"),
     )

--- a/tests/job1/integration_setup.py
+++ b/tests/job1/integration_setup.py
@@ -29,12 +29,12 @@ class Setup(BaseTask):
         )
 
         order_data = [
-            (1, 10, 100.0, "2023-01-01"),
-            (2, 20, 151.0, "2023-01-02"),
-            (None, 10, 100.0, "2023-01-01"),  # id is null
-            (3, 20, 150.0, "2023-01-02"),  # id is duplicated
-            (3, 20, 150.0, "2023-01-02"),
-        ]  # id is duplicated
+            (1, 10, 100.0, "2023-01-01", 1, 1),
+            (2, 20, 1001.0, "2023-01-02", 2, 1),  # total > 1000 → WARN
+            (None, 10, 100.0, "2023-01-01", 1, 1),  # id is null
+            (3, 20, 150.0, "2023-01-02", 3, 2),  # id is duplicated
+            (3, 20, 150.0, "2023-01-02", 3, 2),  # id is duplicated
+        ]
         self.spark.createDataFrame(order_data, schema=order_schema).write.saveAsTable(f"{catalog}.{SCHEMA}.order")
 
         order_item_data = [(1, 1, "Item A", 2, 50.0), (1, 2, "Item B", 1, 50.0), (2, 1, "Item C", 3, 151.0)]
@@ -56,6 +56,8 @@ class Setup(BaseTask):
             ((F.col("id") - 1) % 500 + 1).cast(IntegerType()).alias("id_customer"),
             F.lit(100.0).cast(FloatType()).alias("total"),
             F.lit("2024-01-01").alias("date"),
+            (F.col("id") % 100 + 1).cast(IntegerType()).alias("product_id"),
+            (F.col("id") % 10 + 1).cast(IntegerType()).alias("prod_category_id"),
         ).write.saveAsTable(f"{catalog}.{SCHEMA}.order")
 
         # 6M order_items — 3 items per order, covering all 2M orders

--- a/tests/job1/integration_validate.py
+++ b/tests/job1/integration_validate.py
@@ -1,5 +1,5 @@
 from pyspark.sql import functions as F
-from pyspark.sql.types import DoubleType, LongType, StringType, StructField, StructType
+from pyspark.sql.types import DoubleType, IntegerType, LongType, StringType, StructField, StructType
 from pyspark.testing import assertDataFrameEqual
 
 from template.baseTask import BaseTask
@@ -10,10 +10,17 @@ class Validate(BaseTask):
         super().__init__(config)
 
     def _validate_standard(self, catalog):
-        expected_data = [("John Doe", 3, 100.0), ("Jane Smith", 3, 151.0)]
+        # groupBy(name, date, product_id, prod_category_id) → still 2 rows (one per order)
+        expected_data = [
+            ("John Doe", "2023-01-01", 1, 1, 3, 100.0),
+            ("Jane Smith", "2023-01-02", 2, 1, 3, 151.0),
+        ]
         expected_schema = StructType(
             [
                 StructField("name", StringType(), True),
+                StructField("date", StringType(), True),
+                StructField("product_id", IntegerType(), True),
+                StructField("prod_category_id", IntegerType(), True),
                 StructField("total_qty", LongType(), True),
                 StructField("total_value", DoubleType(), True),
             ]
@@ -28,14 +35,15 @@ class Validate(BaseTask):
             assertDataFrameEqual(df_out, df_expected)
 
     def _validate_load_test(self, catalog):
-        # 500 customers × 4000 orders each × 3 items × qty=2, total_item=50.0
-        # → total_qty=24_000 and total_value=600_000.0 per customer
+        # 500 customers × 100 products × 1 date = 50,000 rows
+        # Each (customer, product): 40 orders × 3 items × qty=2 → total_qty=240
+        # Each (customer, product): 40 orders × 3 items × total_item=50.0 → total_value=6,000.0
         for table in (f"{catalog}.report.order_agg", f"{catalog}.report.order_agg_sdp"):
             df_out = self.spark.table(table)
             count = df_out.count()
-            if count != 500:
-                raise RuntimeError(f"Expected 500 rows in {table}, got {count}")
-            wrong = df_out.filter((F.col("total_qty") != 24_000) | (F.col("total_value") != 600_000.0)).count()
+            if count != 50_000:
+                raise RuntimeError(f"Expected 50,000 rows in {table}, got {count}")
+            wrong = df_out.filter((F.col("total_qty") != 240) | (F.col("total_value") != 6_000.0)).count()
             if wrong > 0:
                 raise RuntimeError(f"{wrong} rows in {table} have unexpected total_qty/total_value")
 

--- a/tests/job1/unit_test.py
+++ b/tests/job1/unit_test.py
@@ -46,11 +46,11 @@ def spark(config) -> TaskConfig:
 @pytest.fixture
 def df_orders_from_source(spark) -> DataFrame:
     order_data = [
-        (1, 10, 100.0, "2023-01-01"),
-        (2, 20, 151.0, "2023-01-02"),
-        (None, 10, 100.0, "2023-01-01"),  # id is null
-        (3, 20, 100.0, "2023-01-02"),  # id is duplicated
-        (3, 20, 100.0, "2023-01-02"),  # id is duplicated
+        (1, 10, 100.0, "2023-01-01", 1, 1),
+        (2, 20, 1001.0, "2023-01-02", 2, 1),  # total > 1000 → WARN
+        (None, 10, 100.0, "2023-01-01", 1, 1),  # id is null
+        (3, 20, 100.0, "2023-01-02", 3, 2),  # id is duplicated
+        (3, 20, 100.0, "2023-01-02", 3, 2),  # id is duplicated
     ]
     return spark.createDataFrame(order_data, schema=order_schema)
 
@@ -58,9 +58,9 @@ def df_orders_from_source(spark) -> DataFrame:
 @pytest.fixture
 def df_orders(spark) -> DataFrame:
     orders_data = [
-        ("John Doe", 10, 1, 100.0, 1, "Item A", 2, 50.0),
-        ("John Doe", 10, 1, 100.0, 2, "Item B", 1, 50.0),
-        ("Jane Smith", 20, 2, 150.0, 1, "Item C", 3, 150.0),
+        ("John Doe", 10, 1, 100.0, "2023-01-01", 1, 1, 1, "Item A", 2, 50.0),
+        ("John Doe", 10, 1, 100.0, "2023-01-01", 1, 1, 2, "Item B", 1, 50.0),
+        ("Jane Smith", 20, 2, 150.0, "2023-01-02", 2, 2, 1, "Item C", 3, 150.0),
     ]
     orders_schema = StructType(
         [
@@ -68,6 +68,9 @@ def df_orders(spark) -> DataFrame:
             StructField("id_customer", IntegerType(), True),
             StructField("id_order", IntegerType(), True),
             StructField("total", FloatType(), True),
+            StructField("date", StringType(), True),
+            StructField("product_id", IntegerType(), True),
+            StructField("prod_category_id", IntegerType(), True),
             StructField("seq", IntegerType(), True),
             StructField("desc_item", StringType(), True),
             StructField("qty", IntegerType(), True),
@@ -163,7 +166,7 @@ def test_enrich_orders(spark, config, df_orders):
     customer_data = [(10, "John Doe", "USA"), (20, "Jane Smith", "UK")]
     df_customer = spark.createDataFrame(customer_data, schema=customer_schema)
 
-    order_data = [(1, 10, 100.0, "2023-01-01"), (2, 20, 150.0, "2023-01-02")]
+    order_data = [(1, 10, 100.0, "2023-01-01", 1, 1), (2, 20, 150.0, "2023-01-02", 2, 2)]
     df_order = spark.createDataFrame(order_data, schema=order_schema)
 
     order_item_data = [(1, 1, "Item A", 2, 50.0), (1, 2, "Item B", 1, 50.0), (2, 1, "Item C", 3, 150.0)]
@@ -184,12 +187,15 @@ def test_aggregate_orders(spark, config, df_orders):
     assert df_out.count() == 2
 
     expected_data = [
-        ("John Doe", 3, 100.0),
-        ("Jane Smith", 3, 150.0),
+        ("John Doe", "2023-01-01", 1, 1, 3, 100.0),
+        ("Jane Smith", "2023-01-02", 2, 2, 3, 150.0),
     ]
     expected_schema = StructType(
         [
             StructField("name", StringType(), True),
+            StructField("date", StringType(), True),
+            StructField("product_id", IntegerType(), True),
+            StructField("prod_category_id", IntegerType(), True),
             StructField("total_qty", LongType(), True),
             StructField("total_value", DoubleType(), True),
         ]

--- a/tests/job1/unit_test.py
+++ b/tests/job1/unit_test.py
@@ -19,13 +19,6 @@ from pyspark.sql.functions import explode
 
 
 @pytest.fixture
-def spark() -> DataFrame:
-    # config = Config(profile = "DEV")
-    # return DatabricksSession.builder.sdkConfig(config).getOrCreate()
-    return SparkSession.builder.appName("unit-tests").getOrCreate()
-
-
-@pytest.fixture
 def config() -> TaskConfig:
     return TaskConfig(
         Namespace(


### PR DESCRIPTION
## Summary

- **Product dimensions**: Added `product_id` (100 distinct) and `prod_category_id` (10 distinct) to the order schema and propagated them through the full pipeline — `commonSchemas.py` → `seed_sources` → `extract_source2` (DQX) → `generate_orders` → `generate_orders_agg` → `job1_sdp/transforms.py`. `report.order_agg` now groups by `name`, `date`, `product_id`, `prod_category_id`.
- **Seed enrichment**: Rewrote the initial load to spread 2M orders across 365 days with varied totals ($10–$990) and 10 countries; incremental daily load raised from 2 000 to 5 000 orders. DQX WARN limit raised from 150 to 1 000 to match the new total range.
- **Truncate script**: Added `scripts/sdk_truncate_tables.py` with a `make truncate env=X yes=--yes` target. Staging/prod require `--yes`; skips non-MANAGED/EXTERNAL table types (e.g. materialized views). Extracted shared `get_warehouse_id` / `run_sql` helpers into `scripts/_sdk_sql.py` (previously duplicated in `sdk_init_workspace.py`).
- **Prod schedule**: Added a 6 am BRT (`America/Sao_Paulo`) daily cron to `job1_prod_integration`.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/job1/unit_test.py`)
- [x] Dev integration tests pass (`make run env=dev`)
- [x] Staging integration tests pass (`make run env=staging`)
- [x] Prod `job1_prod_integration` run SUCCESS — seed → job1 → SDP all green; `report.order_agg` contains `product_id` and `prod_category_id` with correct aggregates

🤖 Generated with [Claude Code](https://claude.com/claude-code)