### PR TITLE
feat: add /project-costs Claude command and make target

### DIFF
--- a/.claude/commands/project-costs.md
+++ b/.claude/commands/project-costs.md
@@ -1,0 +1,21 @@
+Run the project cost script and analyze the output for anomalies, spikes, and trends.
+
+Steps:
+1. Run `make project-costs` via Bash and capture the full output.
+2. Analyze both tables (AWS and Databricks) and produce a written summary with these sections:
+
+**AWS Costs**
+- Total spend for the period and the single biggest cost driver
+- Any day where spend was notably higher than the surrounding baseline — explain what service caused it and how much above average it was
+- Trend: is spend flat, growing, or declining over the period?
+
+**Databricks Costs**
+- Total DBUs consumed (Jobs Serverless + SQL Serverless separately) and total storage DSUs
+- The heaviest-spend days and what drove them (which SKU dominated)
+- Any days with SQL Serverless activity — those indicate interactive/dashboard queries on top of scheduled jobs
+- Trend: is DBU consumption flat, growing, or declining?
+
+**Cross-cloud observation**
+- Note whether AWS S3/egress spikes correlate with high Databricks DBU days (they should — heavy job runs produce more S3 I/O and egress)
+
+Keep the analysis tight: one paragraph per section, specific numbers, no filler.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ notes/
 .databricks/
 .vscode/
 .venv/
-.claude/
+.claude/*
+!.claude/commands/
+!.claude/commands/**
 .pytest_cache/
 dist/
 build/

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,5 @@ run: whoami
 truncate: whoami
 	uv run python ./scripts/sdk_truncate_tables.py $(env) $(yes)
 
+project-costs:
+	uv run python ./scripts/project_costs.py

--- a/scripts/project_costs.py
+++ b/scripts/project_costs.py
@@ -1,0 +1,138 @@
+"""
+Show AWS and Databricks spend for the last 30 days, day by day.
+Usage: uv run python scripts/project_costs.py [--days N] [--profile PROFILE]
+"""
+
+import argparse
+import json
+import subprocess
+import time
+from datetime import date, timedelta
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import StatementState
+
+
+def aws_daily_costs(days: int) -> None:
+    end = date.today()
+    start = end - timedelta(days=days)
+
+    result = subprocess.run(
+        [
+            "aws",
+            "ce",
+            "get-cost-and-usage",
+            "--time-period",
+            f"Start={start},End={end}",
+            "--granularity",
+            "DAILY",
+            "--metrics",
+            "BlendedCost",
+            "--group-by",
+            "Type=DIMENSION,Key=SERVICE",
+            "--output",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"AWS error: {result.stderr.strip()}")
+        return
+
+    data = json.loads(result.stdout)
+
+    print(f"\nAWS Daily Costs — last {days} days")
+    print(f"{'Date':<12} {'Total USD':>10}  Services")
+    print("-" * 80)
+
+    grand_total = 0.0
+    for period in data["ResultsByTime"]:
+        day = period["TimePeriod"]["Start"]
+        estimated = "*" if period.get("Estimated") else " "
+        groups = [(g["Keys"][0], float(g["Metrics"]["BlendedCost"]["Amount"])) for g in period["Groups"]]
+        total = sum(amt for _, amt in groups)
+        grand_total += total
+        services = ", ".join(
+            f"{svc.split()[-1]} ${amt:.4f}" for svc, amt in sorted(groups, key=lambda x: -x[1]) if amt > 0
+        )
+        print(f"{day}{estimated} {total:>10.4f}  {services or '—'}")
+
+    print("-" * 80)
+    print(f"{'Total':<13} {grand_total:>10.4f}")
+    print("* = estimated\n")
+
+
+def databricks_daily_costs(profile: str, days: int) -> None:
+    print(f"Databricks Daily Costs — last {days} days")
+
+    try:
+        w = WorkspaceClient(profile=profile)
+    except Exception as e:
+        print(f"Could not connect to Databricks ({profile} profile): {e}\n")
+        return
+
+    warehouses = list(w.warehouses.list())
+    if not warehouses:
+        print("No SQL warehouse available.\n")
+        return
+    warehouse_id = warehouses[0].id
+
+    sql = f"""
+    SELECT
+      usage_date,
+      sku_name,
+      ROUND(SUM(usage_quantity), 4) AS total_quantity,
+      usage_unit
+    FROM system.billing.usage
+    WHERE usage_date >= CURRENT_DATE() - INTERVAL {days} DAYS
+    GROUP BY usage_date, sku_name, usage_unit
+    ORDER BY usage_date DESC, total_quantity DESC
+    """
+
+    try:
+        stmt = w.statement_execution.execute_statement(
+            warehouse_id=warehouse_id,
+            statement=sql,
+            wait_timeout="30s",
+        )
+        while stmt.status.state not in [
+            StatementState.SUCCEEDED,
+            StatementState.FAILED,
+            StatementState.CANCELED,
+        ]:
+            time.sleep(1)
+            stmt = w.statement_execution.get_statement(stmt.statement_id)
+
+        if stmt.status.state != StatementState.SUCCEEDED:
+            raise RuntimeError(stmt.status.error.message)
+
+        rows = stmt.result.data_array or []
+        if not rows:
+            print("No usage data found.\n")
+            return
+
+        print(f"{'Date':<12} {'SKU':<55} {'Quantity':>10}  Unit")
+        print("-" * 85)
+        for row in rows:
+            print(f"{str(row[0]):<12} {str(row[1]):<55.55} {float(row[2]):>10.4f}  {row[3]}")
+        print()
+
+    except Exception as e:
+        print(f"system.billing.usage not available: {e}")
+        print("Free-tier workspaces don't expose system.billing (requires Premium).\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show AWS and Databricks spend day by day")
+    parser.add_argument("--days", type=int, default=30, help="Number of days to look back (default: 30)")
+    parser.add_argument("--profile", default="dev", help="Databricks CLI profile (default: dev)")
+    args = parser.parse_args()
+
+    aws_daily_costs(args.days)
+    databricks_daily_costs(args.profile, args.days)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/project_costs.py
+++ b/scripts/project_costs.py
@@ -12,36 +12,47 @@ from datetime import date, timedelta
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import StatementState
 
+_POLL_TERMINAL = {StatementState.SUCCEEDED, StatementState.FAILED, StatementState.CANCELED, StatementState.CLOSED}
+
 
 def aws_daily_costs(days: int) -> None:
     end = date.today()
     start = end - timedelta(days=days)
 
-    result = subprocess.run(
-        [
-            "aws",
-            "ce",
-            "get-cost-and-usage",
-            "--time-period",
-            f"Start={start},End={end}",
-            "--granularity",
-            "DAILY",
-            "--metrics",
-            "BlendedCost",
-            "--group-by",
-            "Type=DIMENSION,Key=SERVICE",
-            "--output",
-            "json",
-        ],
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        print(f"AWS error: {result.stderr.strip()}")
+    try:
+        result = subprocess.run(
+            [
+                "aws",
+                "ce",
+                "get-cost-and-usage",
+                "--time-period",
+                f"Start={start},End={end}",
+                "--granularity",
+                "DAILY",
+                "--metrics",
+                "BlendedCost",
+                "--group-by",
+                "Type=DIMENSION,Key=SERVICE",
+                "--output",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("AWS error: AWS CLI not found — install it or ensure it is on PATH.\n")
         return
 
-    data = json.loads(result.stdout)
+    if result.returncode != 0:
+        # Don't echo raw stderr — AWS error messages can include caller ARNs with account IDs.
+        print("AWS error: unable to retrieve cost data (check AWS credentials and ce:GetCostAndUsage permission).\n")
+        return
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print("AWS error: unexpected response from AWS CLI (pager or credential helper output?).\n")
+        return
 
     print(f"\nAWS Daily Costs — last {days} days")
     print(f"{'Date':<12} {'Total USD':>10}  Services")
@@ -70,7 +81,8 @@ def databricks_daily_costs(profile: str, days: int) -> None:
     try:
         w = WorkspaceClient(profile=profile)
     except Exception as e:
-        print(f"Could not connect to Databricks ({profile} profile): {e}\n")
+        # Avoid printing the exception directly — SDK exceptions can include the workspace URL.
+        print(f"Could not connect to Databricks ({profile} profile): {type(e).__name__}\n")
         return
 
     warehouses = list(w.warehouses.list())
@@ -97,16 +109,13 @@ def databricks_daily_costs(profile: str, days: int) -> None:
             statement=sql,
             wait_timeout="30s",
         )
-        while stmt.status.state not in [
-            StatementState.SUCCEEDED,
-            StatementState.FAILED,
-            StatementState.CANCELED,
-        ]:
+        while stmt.status.state not in _POLL_TERMINAL:
             time.sleep(1)
             stmt = w.statement_execution.get_statement(stmt.statement_id)
 
         if stmt.status.state != StatementState.SUCCEEDED:
-            raise RuntimeError(stmt.status.error.message)
+            error_msg = stmt.status.error.message if stmt.status.error else stmt.status.state.value
+            raise RuntimeError(error_msg)
 
         rows = stmt.result.data_array or []
         if not rows:
@@ -129,6 +138,9 @@ def main() -> None:
     parser.add_argument("--days", type=int, default=30, help="Number of days to look back (default: 30)")
     parser.add_argument("--profile", default="dev", help="Databricks CLI profile (default: dev)")
     args = parser.parse_args()
+
+    if args.days < 1:
+        parser.error("--days must be a positive integer")
 
     aws_daily_costs(args.days)
     databricks_daily_costs(args.profile, args.days)


### PR DESCRIPTION
## Summary

- Adds \`scripts/project_costs.py\` — queries AWS Cost Explorer (daily, last 30 days) and Databricks \`system.billing.usage\` via the SDK, printing two formatted tables
- Adds \`make project-costs\` Makefile target as a quick runner
- Adds \`.claude/commands/project-costs.md\` — \`/project-costs\` slash command that fetches the data then has Claude analyze it for anomalies, spikes, period comparisons, and cross-cloud correlation (S3/egress vs DBU spend)
- Updates \`.gitignore\` to track \`.claude/commands/\` so project-level slash commands are shared with the team while personal settings/hooks remain local
- Hardens \`project_costs.py\` against credential leakage and runtime failures: catches \`FileNotFoundError\` when AWS CLI is absent, adds \`StatementState.CLOSED\` to poll-exit set, guards \`stmt.status.error\` before \`.message\` on CANCELED, wraps \`json.loads\` against pager output, replaces raw AWS stderr (which can contain caller ARNs) with a sanitized message, prints \`type(e).__name__\` instead of full SDK exceptions (which can embed the workspace URL), and validates \`--days >= 1\`

## Test plan

- [x] \`make project-costs\` prints both tables (AWS daily + Databricks DBU by SKU)
- [x] \`/project-costs\` in Claude Code runs the script and produces a written analysis with anomaly/spike/trend commentary
- [x] AWS session expired → script prints sanitized error and continues to Databricks section
- [x] Databricks free-tier workspace → script prints fallback message instead of crashing
- [x] Code review findings addressed (credential leakage, infinite poll loop, null deref on cancel, JSON decode crash, negative --days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)