### PR TITLE
feat: add --aws-profile flag to project_costs.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [#39](https://github.com/andre-salvati/databricks-template/pull/39) · 2026-06-11 · feat: add --aws-profile flag to project_costs.py
+
+Added an `--aws-profile` flag to `scripts/project_costs.py` so the AWS Cost Explorer query can target a dedicated AWS CLI profile (`aws_daily_costs` appends `--profile` only when set) instead of relying solely on the default credential chain.
+This unblocks headless runs and lets the script use a scoped read-only Cost Explorer user rather than the expiry-prone browser `aws login` session that this workspace defaults to.
+The flag defaults to `None`, so behavior is unchanged for anyone who does not pass it.
+
+---
+
 ## [#36](https://github.com/andre-salvati/databricks-template/pull/36) · 2026-06-09 · feat: price-freeze incremental silver, liquid clustering, readable labels
 
 Added a mutable `external_source.product` dimension (daily `unit_price` MERGE) and frozen `line_revenue` in silver (`item_quantity × unit_price_at_sale`) so a later price change never restates booked revenue; `job1` freezes via an insert-only `MERGE`, `job1_sdp` via a streaming table + stream-static join — both carrying `product_name` and `category_name` labels through to gold.

--- a/scripts/project_costs.py
+++ b/scripts/project_costs.py
@@ -1,6 +1,6 @@
 """
 Show AWS and Databricks spend for the last 30 days, day by day.
-Usage: uv run python scripts/project_costs.py [--days N] [--profile PROFILE]
+Usage: uv run python scripts/project_costs.py [--days N] [--profile PROFILE] [--aws-profile PROFILE]
 """
 
 import argparse
@@ -15,30 +15,30 @@ from databricks.sdk.service.sql import StatementState
 _POLL_TERMINAL = {StatementState.SUCCEEDED, StatementState.FAILED, StatementState.CANCELED, StatementState.CLOSED}
 
 
-def aws_daily_costs(days: int) -> None:
+def aws_daily_costs(days: int, profile: str | None = None) -> None:
     end = date.today()
     start = end - timedelta(days=days)
 
+    cmd = [
+        "aws",
+        "ce",
+        "get-cost-and-usage",
+        "--time-period",
+        f"Start={start},End={end}",
+        "--granularity",
+        "DAILY",
+        "--metrics",
+        "BlendedCost",
+        "--group-by",
+        "Type=DIMENSION,Key=SERVICE",
+        "--output",
+        "json",
+    ]
+    if profile:
+        cmd += ["--profile", profile]
+
     try:
-        result = subprocess.run(
-            [
-                "aws",
-                "ce",
-                "get-cost-and-usage",
-                "--time-period",
-                f"Start={start},End={end}",
-                "--granularity",
-                "DAILY",
-                "--metrics",
-                "BlendedCost",
-                "--group-by",
-                "Type=DIMENSION,Key=SERVICE",
-                "--output",
-                "json",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True)
     except FileNotFoundError:
         print("AWS error: AWS CLI not found — install it or ensure it is on PATH.\n")
         return
@@ -137,12 +137,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Show AWS and Databricks spend day by day")
     parser.add_argument("--days", type=int, default=30, help="Number of days to look back (default: 30)")
     parser.add_argument("--profile", default="dev", help="Databricks CLI profile (default: dev)")
+    parser.add_argument(
+        "--aws-profile",
+        default=None,
+        help="AWS CLI profile for Cost Explorer (default: AWS default credential chain)",
+    )
     args = parser.parse_args()
 
     if args.days < 1:
         parser.error("--days must be a positive integer")
 
-    aws_daily_costs(args.days)
+    aws_daily_costs(args.days, args.aws_profile)
     databricks_daily_costs(args.profile, args.days)
 
 


### PR DESCRIPTION
## Summary

Adds an `--aws-profile` flag to `scripts/project_costs.py` so the AWS Cost Explorer query can use a dedicated AWS CLI profile instead of only the default credential chain.

## Why

The cost script authenticated solely through the AWS default credential chain. On this workspace that meant a browser-based, expiry-prone `aws login` session (as root), which both breaks unattended runs and is poor credential hygiene. A dedicated, scoped read-only Cost Explorer profile (static keys) makes the script runnable headless and off root.

## Changes

- `aws_daily_costs(days, profile=None)` appends `--profile <profile>` to the `aws ce get-cost-and-usage` call only when a profile is given.
- New `--aws-profile` CLI flag, defaulting to `None` → the AWS default credential chain, so behavior is unchanged for anyone who does not pass it.
- Usage docstring updated.

## Usage

```
uv run python scripts/project_costs.py --aws-profile costs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)